### PR TITLE
Add Dockerfile for Python 3.11 runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Use Python 3.11 slim as base image
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# token.json is not committed. Mount it at runtime:
+#   docker run -v /path/to/token.json:/app/token.json <image>
+# Or include it in the image by uncommenting the line below:
+# COPY token.json /app/token.json
+
+CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
- add Dockerfile using python:3.11-slim base
- install dependencies and run the main script by default
- document how to provide token.json at runtime

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688f12e8e994832ea8ead375391e5353