### PR TITLE
Add Docker-based development and runtime setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+CMD ["python", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.9"
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    volumes:
+      - ./token.json:/app/token.json:ro
+      - ./client_secret.json:/app/client_secret.json:ro
+      - app-data:/data
+    command: python main.py
+
+volumes:
+  app-data:


### PR DESCRIPTION
## Summary
- add Dockerfile to containerize the Python app
- define `app` service in docker-compose with env file, volumes, and command

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f13903bd0832ea16195a1ee35b32f