### PR TITLE
Add dockerignore to shrink build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Exclude version control and related files
+.git
+.gitignore
+
+# Python cache and bytecode
+__pycache__/
+**/__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Logs and temporary files
+*.log
+*.tmp
+*.swp
+*.bak
+
+# IDE/editor configurations
+.vscode/
+.idea/
+
+# Environment and secret files
+token.json
+.env
+*.env
+
+# Build directories
+build/
+dist/
+


### PR DESCRIPTION
## Summary
- add `.dockerignore` to keep git metadata, Python caches, secrets, and build artifacts out of the Docker build context

## Testing
- `pytest`
- `tar -chf - . | wc -c`
- `tar --exclude-from=.dockerignore -chf - . | wc -c`
- `tar --exclude-from=.dockerignore -chf - . | tar -tf - | grep token.json`
- `docker build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f162fb9f4832ea9dacfc831b4659d