### PR TITLE
Add environment variable example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Copy this file to .env before running docker-compose
+
+# API key for OpenAI
+OPENAI_API_KEY=<your-openai-api-key>
+
+# Email address to search for in Gmail
+EMAIL_SENDER=<sender@example.com>
+
+# Base URL of the Jira instance
+JIRA_URL=https://your-jira-instance.atlassian.net
+
+# Key of the Jira project
+JIRA_PROJECT_KEY=PROJ
+
+# Jira username
+JIRA_USER=<your-jira-username>
+
+# Jira API token
+JIRA_API_TOKEN=<your-jira-api-token>
+
+# Custom field ID for the client value
+JIRA_CLIENT_FIELD_ID=<customfield_12345>

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ client_secret.json
 # dotenv files
 .env
 .env.*
+!.env.example
 
 # Output
 *.out

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ docker-compose up
 ```
 
 `docker-compose` will read variables from a `.env` file in the same directory,
-allowing you to store the required environment variables there. Mount the
-`token.json` file as a volume in the compose file so the container can access it.
+allowing you to store the required environment variables there. Copy
+`.env.example` to `.env` and fill in the values before running `docker-compose`
+up. Mount the `token.json` file as a volume in the compose file so the container
+can access it.
 


### PR DESCRIPTION
## Summary
- add `.env.example` listing required variables with placeholders
- document copying `.env.example` to `.env` for docker-compose
- allow `.env.example` to be tracked in git

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f17405a1c832ebf00f90d2931b15c