### PR TITLE
Handle missing GPT classification data

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ def main():
     logger.info(f"Processing email: {email['subject']}")
     gpt_data = gpt_classify_issue(email['subject'], email['body'])
 
-    if not gpt_data.get("issueType"):
+    if not gpt_data or not gpt_data.get("issueType"):
         logger.error("GPT could not classify the issue. Skipping ticket creation.")
         return
 


### PR DESCRIPTION
## Summary
- Guard against missing GPT classification results before creating Jira tickets
- Log an error and skip ticket creation when classification fails

## Testing
- `python -m py_compile main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f1954fdf8832eb874efbb391336b2