### PR TITLE
Ensure dedicated logger always adds its handlers

### DIFF
--- a/logger_setup.py
+++ b/logger_setup.py
@@ -19,6 +19,6 @@ ch.setFormatter(formatter)
 fh.setFormatter(formatter)
 
 # Avoid adding handlers multiple times
-if not logger.hasHandlers():
+if not logger.handlers:
     logger.addHandler(ch)
     logger.addHandler(fh)


### PR DESCRIPTION
## Summary
- Avoid skipping custom logger setup when parent handlers exist

## Testing
- `python -m py_compile logger_setup.py`
- `python - <<'PY'
import logging
import logger_setup
logger = logging.getLogger('g-ai-j')
print('handler types:', [type(h).__name__ for h in logger.handlers])
print('handler count:', len(logger.handlers))
PY`


------
https://chatgpt.com/codex/tasks/task_e_688f19568dd0832eaaa2089afa997aad