### PR TITLE
refactor: simplify volume mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,5 @@ services:
       - .env
     volumes:
       - ./token.json:/app/token.json:ro
-      - ./client_secret.json:/app/client_secret.json:ro
-      - app-data:/data
+      - ./logs:/data
     command: python main.py
-
-volumes:
-  app-data:

--- a/logger_setup.py
+++ b/logger_setup.py
@@ -9,8 +9,8 @@ logger.setLevel(logging.INFO)
 ch = logging.StreamHandler()
 ch.setLevel(logging.INFO)
 
-# File handler
-fh = logging.FileHandler("g-ai-j.log", encoding='utf-8')
+# File handler writing to mounted volume
+fh = logging.FileHandler("/data/g-ai-j.log", encoding='utf-8')
 fh.setLevel(logging.INFO)
 
 # Formatter


### PR DESCRIPTION
## Summary
- replace unused /data volume with mapped logs directory
- drop unused client_secret.json volume and write logs to mounted path

## Testing
- `python -m py_compile logger_setup.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f1957a11c832e878412152a657dab