### PR TITLE
Add Cloud Run service for Gmail-to-Jira integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,36 +1,9 @@
-# Exclude version control and related files
+__pycache__/
+*.pyc
+*.log
+.env
+token.json
+client_secret.json
+*.secret.json
 .git
 .gitignore
-
-# Python cache and bytecode
-__pycache__/
-**/__pycache__/
-*.py[cod]
-*.pyo
-*.pyd
-
-# Virtual environments
-.venv/
-venv/
-env/
-ENV/
-
-# Logs and temporary files
-*.log
-*.tmp
-*.swp
-*.bak
-
-# IDE/editor configurations
-.vscode/
-.idea/
-
-# Environment and secret files
-token.json
-.env
-*.env
-
-# Build directories
-build/
-dist/
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,12 @@
-# Use Python 3.11 slim as base image
 FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy application code
 COPY . .
 
-# token.json is not committed. Mount it at runtime:
-# docker run -v /path/to/token.json:/app/token.json <image>
-# Or include it in the image by uncommenting the line below:
-# COPY token.json /app/token.json
+EXPOSE 8080
 
-CMD ["python", "main.py"]
+CMD ["gunicorn","-w","2","-k","gthread","-b","0.0.0.0:8080","app:app"]

--- a/app.py
+++ b/app.py
@@ -1,0 +1,76 @@
+import base64
+import json
+import os
+from flask import Flask, request
+
+import firestore_state
+import gmail_client
+import jira_client
+from logger_setup import logger
+
+app = Flask(__name__)
+
+DOMAIN_MAP = json.loads(os.getenv("DOMAIN_TO_CLIENT_JSON", "{}"))
+ALLOWED_SENDERS = set(json.loads(os.getenv("ALLOWED_SENDERS_JSON", "[]")))
+
+
+@app.get("/healthz")
+def healthz():
+    return "ok", 200
+
+
+def process_message(message_id: str) -> None:
+    if firestore_state.is_processed(message_id):
+        logger.info("Message %s already processed", message_id)
+        return
+
+    msg = gmail_client.get_message(message_id)
+    sender = msg.get("from", "")
+    if ALLOWED_SENDERS and sender not in ALLOWED_SENDERS:
+        logger.info("Sender %s not allowed", sender)
+        return
+
+    domain = sender.split("@")[-1].lower() if "@" in sender else ""
+    client = DOMAIN_MAP.get(domain, "N/A")
+
+    adf = jira_client.build_adf(msg.get("body_text", ""))
+    labels = ["Billable", f"email_msgid_{msg.get('message_id')}"]
+    key = jira_client.create_ticket(msg.get("subject", "(No Subject)"), adf, client, labels=labels)
+    if key:
+        firestore_state.mark_processed(message_id)
+
+
+@app.post("/pubsub")
+def pubsub_handler():
+    envelope = request.get_json(silent=True)
+    if not envelope or "message" not in envelope:
+        logger.error("Invalid Pub/Sub envelope")
+        return "Bad Request", 400
+
+    msg = envelope["message"]
+    data = msg.get("data")
+    try:
+        payload = json.loads(base64.b64decode(data).decode("utf-8")) if data else {}
+        history_id = int(payload.get("historyId"))
+    except Exception as exc:
+        logger.error("Failed to parse Pub/Sub message: %s", exc)
+        return "Bad Request", 400
+
+    last_history_id = firestore_state.get_last_history_id() or 0
+    if history_id <= last_history_id:
+        logger.info("Received stale historyId %s", history_id)
+        return "", 204
+
+    message_ids = gmail_client.list_new_message_ids_since(last_history_id, history_id)
+    for mid in message_ids:
+        try:
+            process_message(mid)
+        except Exception as exc:
+            logger.error("Error processing message %s: %s", mid, exc)
+
+    firestore_state.set_last_history_id(history_id)
+    return "", 204
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8080)

--- a/firestore_state.py
+++ b/firestore_state.py
@@ -1,0 +1,81 @@
+import os
+from typing import Optional
+from google.cloud import firestore
+from google.api_core import exceptions
+from logger_setup import logger
+
+PROJECT_ID = os.getenv("GCP_PROJECT_ID")
+COLLECTION = os.getenv("GCP_FIRESTORE_COLLECTION", "gaij_state")
+
+_client = firestore.Client(project=PROJECT_ID)
+_collection = _client.collection(COLLECTION)
+
+_MAX_STORED_IDS = 5000
+
+
+def _processed_doc():
+    return _collection.document("processed")
+
+
+def _runtime_doc():
+    return _collection.document("runtime")
+
+
+def _config_doc():
+    return _collection.document("config").collection("watch").document("current")
+
+
+def get_last_history_id() -> Optional[int]:
+    try:
+        doc = _runtime_doc().get()
+        if doc.exists:
+            return int(doc.to_dict().get("last_history_id"))
+    except exceptions.GoogleAPICallError as exc:
+        logger.error("Failed to fetch last_history_id: %s", exc)
+    return None
+
+
+def set_last_history_id(value: int) -> None:
+    try:
+        _runtime_doc().set({"last_history_id": int(value)})
+    except exceptions.GoogleAPICallError as exc:
+        logger.error("Failed to set last_history_id: %s", exc)
+
+
+def is_processed(message_id: str) -> bool:
+    try:
+        doc = _processed_doc().get()
+        ids = doc.to_dict().get("message_ids", []) if doc.exists else []
+        return message_id in ids
+    except exceptions.GoogleAPICallError as exc:
+        logger.error("Failed to check processed message: %s", exc)
+        return False
+
+
+def mark_processed(message_id: str) -> None:
+    try:
+        doc_ref = _processed_doc()
+        doc = doc_ref.get()
+        ids = doc.to_dict().get("message_ids", []) if doc.exists else []
+        ids.append(message_id)
+        if len(ids) > _MAX_STORED_IDS:
+            ids = ids[-_MAX_STORED_IDS:]
+        doc_ref.set({"message_ids": ids})
+    except exceptions.GoogleAPICallError as exc:
+        logger.error("Failed to mark processed message: %s", exc)
+
+
+def get_watch() -> Optional[dict]:
+    try:
+        doc = _config_doc().get()
+        return doc.to_dict() if doc.exists else None
+    except exceptions.GoogleAPICallError as exc:
+        logger.error("Failed to get watch config: %s", exc)
+        return None
+
+
+def set_watch(history_id: int, expiration: int) -> None:
+    try:
+        _config_doc().set({"historyId": int(history_id), "expiration": int(expiration)})
+    except exceptions.GoogleAPICallError as exc:
+        logger.error("Failed to set watch config: %s", exc)

--- a/gmail_watch.py
+++ b/gmail_watch.py
@@ -1,0 +1,42 @@
+import os
+import time
+
+import firestore_state
+import gmail_client
+from logger_setup import logger
+
+
+def register_watch():
+    service = gmail_client.get_gmail_service()
+    user = os.getenv("GMAIL_USER_ID", "me")
+    project = os.getenv("GCP_PROJECT_ID")
+    topic = os.getenv("PUBSUB_TOPIC")
+    body = {
+        "topicName": f"projects/{project}/topics/{topic}",
+        "labelIds": ["INBOX"],
+        "labelFilterAction": "include",
+    }
+    response = service.users().watch(userId=user, body=body).execute()
+    firestore_state.set_watch(response.get("historyId"), response.get("expiration"))
+    firestore_state.set_last_history_id(int(response.get("historyId")))
+    logger.info("Registered Gmail watch: %s", response)
+    return response
+
+
+def renew_watch_if_needed():
+    watch = firestore_state.get_watch()
+    if not watch:
+        logger.info("No existing watch; registering new one")
+        register_watch()
+        return
+    expiration = int(watch.get("expiration", 0))
+    seconds_left = expiration / 1000 - time.time()
+    if seconds_left < 24 * 3600:
+        logger.info("Watch expiring in %.0f seconds; renewing", seconds_left)
+        register_watch()
+    else:
+        logger.info("Watch still valid for %.0f seconds", seconds_left)
+
+
+if __name__ == "__main__":
+    renew_watch_if_needed()

--- a/jira_client.py
+++ b/jira_client.py
@@ -1,14 +1,17 @@
 import os
+from typing import List, Optional
+
 import requests
 from requests.auth import HTTPBasicAuth
 from dotenv import load_dotenv
+
 from logger_setup import logger
 
 load_dotenv()
 
 JIRA_URL = os.getenv("JIRA_URL")
 PROJECT_KEY = os.getenv("JIRA_PROJECT_KEY")
-ASSIGNEE = os.getenv("JIRA_USER")
+ASSIGNEE = os.getenv("JIRA_ASSIGNEE") or os.getenv("JIRA_USER")
 CLIENT_FIELD_ID = os.getenv("JIRA_CLIENT_FIELD_ID")
 
 REQUIRED_ENV_VARS = ["JIRA_URL", "JIRA_PROJECT_KEY", "JIRA_USER", "JIRA_API_TOKEN", "JIRA_CLIENT_FIELD_ID"]
@@ -17,63 +20,45 @@ if missing:
     raise EnvironmentError(f"Missing environment variables: {', '.join(missing)}")
 
 
-def build_jira_description(body, gpt_data):
-    content_blocks = []
-
-    if body and body.strip():
-        content_blocks.append({
-            "type": "paragraph",
-            "content": [{"type": "text", "text": f"📩 Email Body:\n{body.strip()}"}]
-        })
-    else:
-        content_blocks.append({
-            "type": "paragraph",
-            "content": [{"type": "text", "text": "No email body found."}]
-        })
-
-    adf = {
-        "type": "doc",
-        "version": 1,
-        "content": content_blocks
-    }
-
-    logger.info(f"ADF Description payload:\n{adf}")
-    return adf
+def build_adf(text: str) -> dict:
+    lines = text.splitlines() if text else []
+    content = []
+    for line in lines:
+        content.append({"type": "paragraph", "content": [{"type": "text", "text": line}]})
+    if not content:
+        content.append({"type": "paragraph"})
+    return {"type": "doc", "version": 1, "content": content}
 
 
-def create_jira_ticket(summary, body, issue_type, client, gpt_data, attachments=[]):
+def create_ticket(summary: str, adf_description: dict, client: str, issue_type: str = "Task", labels: Optional[List[str]] = None, assignee: Optional[str] = None) -> Optional[str]:
+    if labels is None:
+        labels = ["Billable"]
     url = f"{JIRA_URL}/rest/api/3/issue"
     auth = HTTPBasicAuth(os.getenv("JIRA_USER"), os.getenv("JIRA_API_TOKEN"))
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
 
-    payload = {
-        "fields": {
-            "project": {"key": PROJECT_KEY},
-            "summary": summary,
-            "description": build_jira_description(body, gpt_data),
-            "issuetype": {"name": issue_type},
-            CLIENT_FIELD_ID: [{"value": client}],
-            "assignee": {"name": ASSIGNEE},
-            "labels": ["Billable"],
-            "priority": {"name": "Medium"},
-        }
+    fields = {
+        "project": {"key": PROJECT_KEY},
+        "summary": summary,
+        "description": adf_description,
+        "issuetype": {"name": issue_type},
+        CLIENT_FIELD_ID: [{"value": client}],
+        "labels": labels,
+        "priority": {"name": "Medium"},
     }
+    assignee = assignee or ASSIGNEE
+    if assignee:
+        fields["assignee"] = {"emailAddress": assignee}
+
+    payload = {"fields": fields}
 
     try:
-        response = requests.post(
-            url,
-            auth=auth,
-            headers=headers,
-            json=payload,
-            timeout=10
-        )
+        response = requests.post(url, auth=auth, headers=headers, json=payload, timeout=10)
         if response.status_code == 201:
-            logger.info("Jira ticket created: %s", response.json().get("key"))
-        else:
-            logger.error(
-                "Failed to create Jira ticket: %s %s",
-                response.status_code,
-                response.text,
-            )
+            key = response.json().get("key")
+            logger.info("Jira ticket created: %s", key)
+            return key
+        logger.error("Failed to create Jira ticket: %s %s", response.status_code, response.text)
     except requests.RequestException as exc:
         logger.error("Request to Jira failed: %s", exc)
+    return None

--- a/logger_setup.py
+++ b/logger_setup.py
@@ -5,20 +5,10 @@ import logging
 logger = logging.getLogger("g-ai-j")
 logger.setLevel(logging.INFO)
 
-# Console handler
-ch = logging.StreamHandler()
-ch.setLevel(logging.INFO)
-
-# File handler writing to mounted volume
-fh = logging.FileHandler("/data/g-ai-j.log", encoding='utf-8')
-fh.setLevel(logging.INFO)
-
-# Formatter
+handler = logging.StreamHandler()
+handler.setLevel(logging.INFO)
 formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(message)s')
-ch.setFormatter(formatter)
-fh.setFormatter(formatter)
+handler.setFormatter(formatter)
 
-# Avoid adding handlers multiple times
 if not logger.handlers:
-    logger.addHandler(ch)
-    logger.addHandler(fh)
+    logger.addHandler(handler)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
-google-api-python-client
-google-auth-httplib2
-google-auth-oauthlib
-openai
-requests
-python-dotenv
-beautifulsoup4
+Flask==3.*
+gunicorn==21.*
+google-api-python-client==2.*
+google-auth==2.*
+google-auth-oauthlib==1.*
+google-cloud-firestore==2.*
+requests==2.*
+beautifulsoup4==4.*
+python-dotenv==1.*
+openai==1.*


### PR DESCRIPTION
## Summary
- serve Gmail push notifications on Cloud Run and create Jira tickets without duplicates
- persist Gmail history and processed messages in Firestore
- add Gmail watch renewal helper and modernize dependencies/Docker image

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a38065ce30832e997904296aa90d3a