### PR TITLE
Add validation test suite and helper seams

### DIFF
--- a/README_validations.md
+++ b/README_validations.md
@@ -1,0 +1,38 @@
+# Validation Plan
+
+This repository includes a pytest suite that exercises the core workflows of
+`g-ai-j` using mocked external services.  The tests cover:
+
+* **Pub/Sub handler** – happy path, duplicate history IDs, and duplicate message
+  IDs.  Verifies Gmail parsing, client mapping, Jira payloads, Firestore updates
+  and idempotency.
+* **Gmail MIME parsing** – extraction of text from HTML bodies and nested
+  multipart structures.
+* **Jira ADF building** – multi-line body to ADF paragraphs and correct custom
+  field/label formatting when creating issues.
+* **Firestore state** – reading/writing `last_history_id`, tracking processed
+  message IDs with pruning.
+* **Gmail watch renewal** – registering a watch and renewing when expiration is
+  near.
+
+All external dependencies (Gmail API, Jira, Firestore, OpenAI) are replaced with
+in-memory fakes or mocks, so the suite runs offline and is deterministic.
+
+## Running the tests locally
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+## Running with Docker
+
+```bash
+docker build -t g-ai-j .
+docker run --rm -v "$PWD":/app g-ai-j pytest
+```
+
+## Running in CI
+
+Configure the CI job to install dependencies and execute `pytest` in the project
+root.  No network access or secrets are required for the tests.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,96 @@
+import base64
+import json
+import importlib
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+from google.cloud import firestore as firestore_mod
+
+# Ensure the repository root is on the import path so application modules can
+# be imported when tests run from the `tests/` directory.
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+class FakeDocument:
+    def __init__(self, store, path):
+        self.store = store
+        self.path = path
+
+    def get(self):
+        data = self.store.get(self.path)
+        return SimpleNamespace(
+            exists=data is not None,
+            to_dict=lambda: data or {},
+        )
+
+    def set(self, data):
+        self.store[self.path] = data
+
+    def collection(self, name):
+        return FakeCollection(self.store, f"{self.path}/{name}")
+
+
+class FakeCollection:
+    def __init__(self, store, path):
+        self.store = store
+        self.path = path
+
+    def document(self, name):
+        return FakeDocument(self.store, f"{self.path}/{name}")
+
+
+class FakeFirestoreClient:
+    def __init__(self, project=None):
+        self.store = {}
+
+    def collection(self, name):
+        return FakeCollection(self.store, name)
+
+
+@pytest.fixture
+def firestore_state_module(monkeypatch):
+    """Provide the firestore_state module backed by an in-memory store."""
+    monkeypatch.setattr(firestore_mod, "Client", FakeFirestoreClient)
+    import firestore_state
+    importlib.reload(firestore_state)
+    return firestore_state
+
+
+@pytest.fixture
+def app_setup(monkeypatch, firestore_state_module):
+    """Set up application modules with fakes and return references."""
+    monkeypatch.setenv("JIRA_URL", "https://example.atlassian.net")
+    monkeypatch.setenv("JIRA_USER", "user@example.com")
+    monkeypatch.setenv("JIRA_API_TOKEN", "token")
+    monkeypatch.setenv("JIRA_PROJECT_KEY", "UIV4")
+    monkeypatch.setenv("JIRA_ASSIGNEE", "assignee@example.com")
+    monkeypatch.setenv("JIRA_CLIENT_FIELD_ID", "customfield_10000")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    domain_map = {"oetraining.com": "OETraining"}
+    monkeypatch.setenv("DOMAIN_TO_CLIENT_JSON", json.dumps(domain_map))
+
+    import gmail_client, jira_client, gpt_agent, app
+    importlib.reload(gmail_client)
+    importlib.reload(jira_client)
+    importlib.reload(gpt_agent)
+    importlib.reload(app)
+
+    client = app.app.test_client()
+    return {
+        "client": client,
+        "firestore_state": firestore_state_module,
+        "gmail_client": gmail_client,
+        "jira_client": jira_client,
+        "gpt_agent": gpt_agent,
+        "app": app,
+    }
+
+
+@pytest.fixture
+def pubsub_envelope():
+    payload = base64.b64encode(
+        json.dumps({"emailAddress": "me", "historyId": "12345"}).encode()
+    ).decode()
+    return {"message": {"data": payload}}

--- a/tests/test_firestore_state.py
+++ b/tests/test_firestore_state.py
@@ -1,0 +1,15 @@
+
+def test_history_id_roundtrip(firestore_state_module):
+    fs = firestore_state_module
+    assert fs.get_last_history_id() is None
+    fs.set_last_history_id(100)
+    assert fs.get_last_history_id() == 100
+
+
+def test_mark_processed_prunes(firestore_state_module, monkeypatch):
+    fs = firestore_state_module
+    monkeypatch.setattr(fs, "_MAX_STORED_IDS", 3)
+    for i in range(5):
+        fs.mark_processed(f"M{i}")
+    assert fs.is_processed("M4")
+    assert not fs.is_processed("M0")

--- a/tests/test_gmail_client_parsing.py
+++ b/tests/test_gmail_client_parsing.py
@@ -1,0 +1,31 @@
+import base64
+
+
+def test_extract_body_html(app_setup):
+    gmail_client = app_setup["gmail_client"]
+    payload = {
+        "mimeType": "text/html",
+        "body": {"data": base64.urlsafe_b64encode(b"<p>Hello <b>World</b></p>").decode()},
+    }
+    assert gmail_client.extract_body(payload) == "Hello World"
+
+
+def test_extract_body_nested_multipart(app_setup):
+    gmail_client = app_setup["gmail_client"]
+    payload = {
+        "mimeType": "multipart/alternative",
+        "parts": [
+            {
+                "mimeType": "multipart/mixed",
+                "parts": [
+                    {
+                        "mimeType": "text/html",
+                        "body": {
+                            "data": base64.urlsafe_b64encode(b"<p>Inner HTML</p>").decode()
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+    assert gmail_client.extract_body(payload) == "Inner HTML"

--- a/tests/test_jira_client_adf.py
+++ b/tests/test_jira_client_adf.py
@@ -1,0 +1,33 @@
+
+def test_build_adf(app_setup):
+    jira_client = app_setup["jira_client"]
+    text = "Line1\nLine2"
+    adf = jira_client.build_adf(text)
+    assert adf["content"][0]["content"][0]["text"] == "Line1"
+    assert adf["content"][1]["content"][0]["text"] == "Line2"
+
+
+def test_create_ticket_payload(monkeypatch, app_setup):
+    jira_client = app_setup["jira_client"]
+    captured = {}
+
+    def fake_post(url, auth=None, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        class Resp:
+            status_code = 201
+            def json(self):
+                return {"key": "ABC-1"}
+        return Resp()
+
+    monkeypatch.setattr(jira_client.requests, "post", fake_post)
+    key = jira_client.create_ticket(
+        "Summary",
+        {"type": "doc", "content": []},
+        "OETraining",
+        labels=["Billable", "email_msgid_abc"],
+    )
+    assert key == "ABC-1"
+    fields = captured["json"]["fields"]
+    assert fields[jira_client.CLIENT_FIELD_ID] == [{"value": "OETraining"}]
+    assert "email_msgid_abc" in fields["labels"]

--- a/tests/test_pubsub_handler.py
+++ b/tests/test_pubsub_handler.py
@@ -1,0 +1,85 @@
+import json
+
+
+def test_pubsub_happy_path(app_setup, pubsub_envelope, monkeypatch):
+    client = app_setup["client"]
+    fs = app_setup["firestore_state"]
+    gmail_client = app_setup["gmail_client"]
+    jira_client = app_setup["jira_client"]
+    gpt_agent = app_setup["gpt_agent"]
+
+    monkeypatch.setattr(gmail_client, "list_new_message_ids_since", lambda s, e: ["A1"])
+    monkeypatch.setattr(
+        gmail_client,
+        "get_message",
+        lambda mid: {
+            "from": "Marisa@oetraining.com",
+            "subject": "Add County",
+            "message_id": "<abc@googlemail.com>",
+            "body_text": "Line1\nLine2",
+        },
+    )
+    monkeypatch.setattr(gpt_agent, "gpt_classify_issue", lambda s, b: {"issueType": "Task"})
+
+    called = {}
+
+    def fake_create(summary, adf, client_name, issue_type="Task", labels=None):
+        called["summary"] = summary
+        called["client"] = client_name
+        called["labels"] = labels
+        return "JIRA-1"
+
+    monkeypatch.setattr(jira_client, "create_ticket", fake_create)
+
+    res = client.post("/pubsub", json=pubsub_envelope)
+    assert res.status_code == 204
+    assert fs.get_last_history_id() == 12345
+    assert fs.is_processed("A1")
+    assert called["client"] == "OETraining"
+    assert "email_msgid_<abc@googlemail.com>" in called["labels"]
+
+
+def test_pubsub_duplicate_history(app_setup, pubsub_envelope, monkeypatch):
+    client = app_setup["client"]
+    fs = app_setup["firestore_state"]
+    fs.set_last_history_id(12345)
+
+    listed = {"called": False}
+
+    def fake_list(start, end):
+        listed["called"] = True
+        return []
+
+    monkeypatch.setattr(app_setup["gmail_client"], "list_new_message_ids_since", fake_list)
+    res = client.post("/pubsub", json=pubsub_envelope)
+    assert res.status_code == 204
+    assert listed["called"] is False
+
+
+def test_pubsub_duplicate_message(app_setup, pubsub_envelope, monkeypatch):
+    client = app_setup["client"]
+    fs = app_setup["firestore_state"]
+    gmail_client = app_setup["gmail_client"]
+    jira_client = app_setup["jira_client"]
+
+    fs.mark_processed("A1")
+    monkeypatch.setattr(gmail_client, "list_new_message_ids_since", lambda s, e: ["A1"])
+
+    called = {"get": False, "ticket": False}
+
+    def fake_get(mid):
+        called["get"] = True
+        return {}
+
+    def fake_ticket(*args, **kwargs):
+        called["ticket"] = True
+        return "JIRA-1"
+
+    monkeypatch.setattr(gmail_client, "get_message", fake_get)
+    monkeypatch.setattr(jira_client, "create_ticket", fake_ticket)
+
+    res = client.post("/pubsub", json=pubsub_envelope)
+    assert res.status_code == 204
+    assert not called["get"]
+    assert not called["ticket"]
+    assert fs.get_last_history_id() == 12345

--- a/tests/test_watch_gmail.py
+++ b/tests/test_watch_gmail.py
@@ -1,0 +1,47 @@
+import importlib
+import time
+
+
+def test_register_watch(monkeypatch, firestore_state_module):
+    import gmail_watch
+    importlib.reload(gmail_watch)
+
+    class FakeService:
+        def users(self):
+            return self
+
+        def watch(self, userId, body):
+            self.body = body
+            return self
+
+        def execute(self):
+            return {"historyId": "99", "expiration": 2000}
+
+    monkeypatch.setenv("GCP_PROJECT_ID", "proj")
+    monkeypatch.setenv("PUBSUB_TOPIC", "gmail-notifications")
+    monkeypatch.setattr(gmail_watch.gmail_client, "get_gmail_service", lambda: FakeService())
+
+    gmail_watch.register_watch()
+    watch = firestore_state_module.get_watch()
+    assert watch["historyId"] == 99
+    assert firestore_state_module.get_last_history_id() == 99
+
+
+def test_renew_watch_if_expiring(monkeypatch, firestore_state_module):
+    import gmail_watch
+    importlib.reload(gmail_watch)
+
+    called = {"registered": False}
+
+    def fake_register():
+        called["registered"] = True
+
+    monkeypatch.setattr(gmail_watch, "register_watch", fake_register)
+    monkeypatch.setattr(
+        firestore_state_module,
+        "get_watch",
+        lambda: {"expiration": int((time.time() + 3600) * 1000)},
+    )
+
+    gmail_watch.renew_watch_if_needed()
+    assert called["registered"] is True


### PR DESCRIPTION
## Summary
- add pytest suite covering Pub/Sub handler, Gmail parsing, Jira ADF, Firestore state and watch renewal
- document validation scenarios and how to run tests
- allow Firestore client injection by lazily creating the client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a389eac190832e89e5281dc110f6a5