### PR TITLE
Add CI/CD pipeline for Cloud Run

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -1,0 +1,37 @@
+name: Test and Deploy
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pip install pytest
+      - run: pytest
+
+  deploy:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+      - uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ secrets.CLOUD_RUN_SERVICE }}
+          region: ${{ secrets.GCP_REGION }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          source: .

--- a/README.md
+++ b/README.md
@@ -77,3 +77,29 @@ docker run --rm -p 8080:8080 g-ai-j
 ```
 
 Cloud Run reads logs from stdout; the application does not write to local files.
+
+## Continuous Integration / Deployment
+
+This repository includes a GitHub Actions workflow that runs the test suite on
+every push and pull request. Pushes to the `main` branch will deploy the
+application to Cloud Run after tests pass.
+
+### GitHub configuration
+
+Store the following secrets in your repository settings:
+
+| Secret | Purpose |
+| --- | --- |
+| `GCP_PROJECT_ID` | Google Cloud project that hosts Cloud Run |
+| `GCP_REGION` | Region for the Cloud Run service (e.g. `us-central1`) |
+| `CLOUD_RUN_SERVICE` | Name of the Cloud Run service |
+| `GCP_SA_KEY` | JSON key for a service account used for deployment |
+
+### Google Cloud configuration
+
+1. Create a service account and download a JSON key. Grant it **Cloud Run
+   Admin**, **Service Account User**, and **Cloud Build Editor** roles.
+2. Enable the Cloud Run and Cloud Build APIs.
+3. Pre-create the Cloud Run service or allow the workflow to create it on the
+   first deploy. Configure required environment variables in Cloud Run.
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests and deploy to Cloud Run
- document required GitHub secrets and GCP setup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4139e3d24832e8debb969151f6397