### PR TITLE
Handle missing GCP creds in deploy workflow

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
 
   deploy:
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.GCP_SA_KEY != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Skip Cloud Run deployment when GCP_SA_KEY secret is unavailable to avoid google-github-actions/auth failure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a45d0afb2c832e9f21c40fb9924088