### PR TITLE
fix: avoid secret in workflow condition

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
 
   deploy:
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.GCP_SA_KEY != ''
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- fix GitHub Actions workflow failing to parse by removing reference to secrets in job-level condition

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a45e992a1c832e88f02faf57b29186