### PR TITLE
Fix Gmail message ID header extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Utility that turns Gmail messages into Jira tickets. In addition to the original
 | File | Purpose |
 | --- | --- |
 | `app.py` | Flask service for Cloud Run. Handles `/healthz` and `/pubsub` endpoints. |
-| `gmail_client.py` | Wrapper around Gmail API. Fetches messages and lists history updates. |
+| `gmail_client.py` | Wrapper around Gmail API. Fetches messages, lists history updates, and extracts headers including `Message-ID` for deduplication. |
 | `jira_client.py` | Creates Jira issues with ADF descriptions and client custom field. |
 | `firestore_state.py` | Persists last processed history ID and recent message IDs in Firestore. |
 | `gmail_watch.py` | Helper script to register or renew Gmail `users.watch`. |
@@ -46,7 +46,7 @@ Utility that turns Gmail messages into Jira tickets. In addition to the original
    Re-run periodically (e.g. via Cloud Scheduler) to renew the watch before expiration.
 
 
-When Gmail pushes a notification to Pub/Sub, `app.py` retrieves new messages, asks GPT to classify the issue and determine the client from the email body, creates Jira tickets, and records processed message IDs in Firestore to avoid duplicates.
+When Gmail pushes a notification to Pub/Sub, `app.py` retrieves new messages, asks GPT to classify the issue and determine the client from the email body, creates Jira tickets, and records processed message IDs in Firestore to avoid duplicates. The `Message-ID` header is used to track each email reliably.
 
 
 ## Required environment variables

--- a/gmail_client.py
+++ b/gmail_client.py
@@ -41,12 +41,18 @@ def extract_body(payload: Dict) -> str:
 
 
 def extract_headers(headers: List[Dict]) -> Dict[str, str]:
-    desired = {"From": "", "Subject": "", "Date": "", "Message-Id": ""}
+    """Return a subset of headers with case-insensitive matching."""
+    desired = {"from": "", "subject": "", "date": "", "message-id": ""}
     for header in headers:
-        name = header.get("name")
+        name = header.get("name", "").lower()
         if name in desired:
             desired[name] = header.get("value", "")
-    return desired
+    return {
+        "From": desired["from"],
+        "Subject": desired["subject"],
+        "Date": desired["date"],
+        "Message-ID": desired["message-id"],
+    }
 
 
 def list_new_message_ids_since(start_history_id: int, end_history_id: int) -> List[str]:
@@ -86,7 +92,7 @@ def get_message(message_id: str, format: str = "full") -> Dict[str, str]:
         "from": headers.get("From"),
         "subject": headers.get("Subject"),
         "date": headers.get("Date"),
-        "message_id": headers.get("Message-Id"),
+        "message_id": headers.get("Message-ID"),
         "body_text": body_text,
     }
 

--- a/tests/test_gmail_client_parsing.py
+++ b/tests/test_gmail_client_parsing.py
@@ -29,3 +29,13 @@ def test_extract_body_nested_multipart(app_setup):
         ],
     }
     assert gmail_client.extract_body(payload) == "Inner HTML"
+
+
+def test_extract_headers_message_id(app_setup):
+    gmail_client = app_setup["gmail_client"]
+    headers = [
+        {"name": "From", "value": "foo@example.com"},
+        {"name": "Message-ID", "value": "<id1@example.com>"},
+    ]
+    result = gmail_client.extract_headers(headers)
+    assert result.get("Message-ID") == "<id1@example.com>"


### PR DESCRIPTION
## Summary
- handle Message-ID header case-insensitively in Gmail client and expose via get_message
- document Message-ID usage for deduplication
- test Gmail header parsing for Message-ID

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a479c3136c832ebf69beb95846277c