### PR TITLE
Sanitize Gmail message ID for Jira labels

### DIFF
--- a/tests/test_pubsub_handler.py
+++ b/tests/test_pubsub_handler.py
@@ -37,7 +37,7 @@ def test_pubsub_happy_path(app_setup, pubsub_envelope, monkeypatch):
     assert fs.get_last_history_id() == 12345
     assert fs.is_processed("A1")
     assert called["client"] == "OETraining"
-    assert "email_msgid_<abc@googlemail.com>" in called["labels"]
+    assert "email_msgid_abc-googlemail-com" in called["labels"]
 
 
 def test_pubsub_duplicate_history(app_setup, pubsub_envelope, monkeypatch):


### PR DESCRIPTION
## Summary
- sanitize message IDs when generating Jira labels by stripping angle brackets, replacing illegal characters, and skipping if empty
- add regex dependency and adjust label creation logic
- update pubsub handler tests to expect sanitized label

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4891cc508832ebdb730eb66d689c8