### PR TITLE
Cache Gmail service instance

### DIFF
--- a/gmail_client.py
+++ b/gmail_client.py
@@ -10,15 +10,23 @@ from logger_setup import logger
 
 SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
 
+# Cached Gmail API service instance
+_service = None
+
 
 def get_gmail_service():
+    global _service
+    if _service is not None:
+        return _service
+
     token_path = "token.json"
     if not os.path.exists(token_path):
         logger.error("Gmail token file not found at %s", token_path)
         raise FileNotFoundError(token_path)
 
     creds = Credentials.from_authorized_user_file(token_path, SCOPES)
-    return build("gmail", "v1", credentials=creds)
+    _service = build("gmail", "v1", credentials=creds)
+    return _service
 
 
 def extract_body(payload: Dict) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,7 @@ def app_setup(monkeypatch, firestore_state_module):
     importlib.reload(jira_client)
     importlib.reload(gpt_agent)
     importlib.reload(app)
+    gmail_client._service = None
 
     client = app.app.test_client()
     return {


### PR DESCRIPTION
## Summary
- cache Gmail API service in `gmail_client.get_gmail_service`
- reset cached Gmail service during test setup

## Testing
- `pytest tests/test_gmail_client_parsing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4891fd260832ebcf249dbdc7b82ce