### PR TITLE
Handle invalid last_history_id values

### DIFF
--- a/firestore_state.py
+++ b/firestore_state.py
@@ -40,7 +40,12 @@ def get_last_history_id() -> Optional[int]:
     try:
         doc = _runtime_doc().get()
         if doc.exists:
-            return int(doc.to_dict().get("last_history_id"))
+            value = doc.to_dict().get("last_history_id")
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                logger.warning("Invalid last_history_id value: %r", value)
+                return None
     except exceptions.GoogleAPICallError as exc:
         logger.error("Failed to fetch last_history_id: %s", exc)
     return None

--- a/tests/test_firestore_state.py
+++ b/tests/test_firestore_state.py
@@ -13,3 +13,19 @@ def test_mark_processed_prunes(firestore_state_module, monkeypatch):
         fs.mark_processed(f"M{i}")
     assert fs.is_processed("M4")
     assert not fs.is_processed("M0")
+
+
+def test_get_last_history_id_invalid_value_warns(firestore_state_module, caplog):
+    fs = firestore_state_module
+    fs._runtime_doc().set({"last_history_id": "bad"})
+    with caplog.at_level("WARNING"):
+        assert fs.get_last_history_id() is None
+        assert "Invalid last_history_id value" in caplog.text
+
+
+def test_get_last_history_id_none_value_warns(firestore_state_module, caplog):
+    fs = firestore_state_module
+    fs._runtime_doc().set({"last_history_id": None})
+    with caplog.at_level("WARNING"):
+        assert fs.get_last_history_id() is None
+        assert "Invalid last_history_id value" in caplog.text


### PR DESCRIPTION
## Summary
- Validate `last_history_id` retrieval in Firestore state, logging warnings for invalid values
- Test `get_last_history_id` for invalid stored data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4891e8c88832ea282ac8bee82089a