### PR TITLE
Stream Gmail history IDs to reduce memory

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,9 +95,8 @@ def pubsub_handler():
         logger.info("Received stale historyId %s", history_id)
         return "", 204
 
-    message_ids = gmail_client.list_new_message_ids_since(last_history_id, history_id)
     failed = False
-    for mid in message_ids:
+    for mid in gmail_client.list_new_message_ids_since(last_history_id, history_id):
         try:
             process_message(mid)
         except Exception as exc:

--- a/tests/test_gmail_client_parsing.py
+++ b/tests/test_gmail_client_parsing.py
@@ -64,7 +64,7 @@ def test_list_new_message_ids_since_api_error(app_setup, monkeypatch):
 
     monkeypatch.setattr(gmail_client, "get_gmail_service", lambda: Service())
 
-    assert gmail_client.list_new_message_ids_since(1, 2) == []
+    assert list(gmail_client.list_new_message_ids_since(1, 2)) == []
 
 
 def test_get_message_api_error(app_setup, monkeypatch):


### PR DESCRIPTION
## Summary
- Stream Gmail history message IDs instead of collecting a list to lower memory usage
- Adjust endpoint to iterate over streamed IDs
- Update tests for new generator behavior

## Testing
- `pytest -q`
- `python - <<'PY'
import tracemalloc
import gmail_client

class FakeList:
    def __init__(self, batches, batch_size):
        self.batches = batches
        self.batch_size = batch_size
        self.calls = 0
    def execute(self):
        if self.calls >= self.batches:
            return {}
        start = self.calls * self.batch_size
        history = [
            {"messagesAdded": [{"message": {"id": f"id{start+i}"}} for i in range(self.batch_size)]}
        ]
        self.calls += 1
        resp = {"history": history}
        if self.calls < self.batches:
            resp["nextPageToken"] = str(self.calls)
        return resp
    def history(self):
        return self
    def list(self, **kwargs):
        return self

class FakeUsers:
    def __init__(self, list_obj):
        self.list_obj = list_obj
    def history(self):
        return self.list_obj

class FakeService:
    def __init__(self, list_obj):
        self.list_obj = list_obj
    def users(self):
        return FakeUsers(self.list_obj)

BATCHES = 50
BATCH_SIZE = 1000

fake_list = FakeList(BATCHES, BATCH_SIZE)
fake_service = FakeService(fake_list)
gmail_client.get_gmail_service = lambda: fake_service

def old_impl():
    service = gmail_client.get_gmail_service()
    user_id = "me"
    msg_ids = set()
    page_token = None
    while True:
        req = {
            "userId": user_id,
            "startHistoryId": 1,
            "historyTypes": ["messageAdded"],
        }
        if page_token:
            req["pageToken"] = page_token
        resp = service.users().history().list(**req).execute()
        for history in resp.get("history", []):
            for added in history.get("messagesAdded", []):
                msg_ids.add(added.get("message", {}).get("id"))
        page_token = resp.get("nextPageToken")
        if not page_token:
            break
    return list(msg_ids)

tracemalloc.start()
old_ids = old_impl()
current, peak_old = tracemalloc.get_traced_memory()
tracemalloc.stop()

fake_list = FakeList(BATCHES, BATCH_SIZE)
fake_service = FakeService(fake_list)
gmail_client.get_gmail_service = lambda: fake_service

tracemalloc.start()
for _ in gmail_client.list_new_message_ids_since(1,2):
    pass
current, peak_new = tracemalloc.get_traced_memory()
tracemalloc.stop()

print("old peak", peak_old)
print("new peak", peak_new)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a49d0a6cc0832e9b5fa58abac09a06