### PR TITLE
Add startup configuration validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Utility that turns Gmail messages into Jira tickets. In addition to the original
    ```
    Re-run periodically (e.g. via Cloud Scheduler) to renew the watch before expiration.
 
+The service validates its configuration at startup and will exit if required
+Jira environment variables are missing or if `token.json` is absent. Ensure
+these are set before deployment so the container fails fast on
+misconfiguration.
+
 
 When Gmail pushes a notification to Pub/Sub, `app.py` retrieves new messages, asks GPT to classify the issue and determine the client from the email body, creates Jira tickets, and records processed message IDs in Firestore to avoid duplicates. The `Message-ID` header is used to track each email reliably.
 

--- a/app.py
+++ b/app.py
@@ -12,7 +12,29 @@ from gpt_agent import gpt_classify_issue
 
 from logger_setup import logger
 
+
+REQUIRED_ENV_VARS = [
+    "JIRA_URL",
+    "JIRA_PROJECT_KEY",
+    "JIRA_USER",
+    "JIRA_API_TOKEN",
+    "JIRA_CLIENT_FIELD_ID",
+]
+
+
+def validate_config() -> None:
+    missing = [var for var in REQUIRED_ENV_VARS if not os.getenv(var)]
+    if not os.path.exists("token.json"):
+        raise FileNotFoundError("token.json not found")
+    if missing:
+        raise EnvironmentError(
+            f"Missing environment variables: {', '.join(missing)}"
+        )
+    logger.info("Configuration validated")
+
+
 app = Flask(__name__)
+validate_config()
 
 DOMAIN_MAP = json.loads(os.getenv("DOMAIN_TO_CLIENT_JSON", "{}"))
 ALLOWED_SENDERS = set(json.loads(os.getenv("ALLOWED_SENDERS_JSON", "[]")))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,12 @@ def app_setup(monkeypatch, firestore_state_module):
     domain_map = {"oetraining.com": "OETraining"}
     monkeypatch.setenv("DOMAIN_TO_CLIENT_JSON", json.dumps(domain_map))
 
+    token_path = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "token.json"
+    )
+    with open(token_path, "w") as f:
+        json.dump({}, f)
+
     import gmail_client, jira_client, gpt_agent, app
     importlib.reload(gmail_client)
     importlib.reload(jira_client)


### PR DESCRIPTION
## Summary
- validate required JIRA env vars and token.json on startup
- document configuration validation in deployment instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4a9024274832e8199bce107a747f2