### PR TITLE
Normalize sender email comparison

### DIFF
--- a/tests/test_allowed_senders.py
+++ b/tests/test_allowed_senders.py
@@ -1,0 +1,33 @@
+import importlib
+import json
+
+
+def test_sender_normalization(monkeypatch, app_setup):
+    monkeypatch.setenv("ALLOWED_SENDERS_JSON", json.dumps(["Oleh@Get-Code.net"]))
+    import app
+    app = importlib.reload(app)
+
+    assert "oleh@get-code.net" in app.ALLOWED_SENDERS
+
+    called = {"ticket": False}
+
+    monkeypatch.setattr(app, "gpt_classify_issue", lambda s, b: {})
+    monkeypatch.setattr(
+        app.gmail_client,
+        "get_message",
+        lambda mid: {
+            "from": "Oleh Mordach <oleh@get-code.net>",
+            "subject": "hi",
+            "body_text": "",
+        },
+    )
+
+    def fake_create(summary, adf, client, issue_type="Task", labels=None):
+        called["ticket"] = True
+        return "JIRA-1"
+
+    monkeypatch.setattr(app.jira_client, "create_ticket", fake_create)
+
+    app.process_message("A1")
+    assert called["ticket"]
+


### PR DESCRIPTION
## Summary
- Normalize allowed sender emails to lowercase and parse `From` headers for address comparison
- Log both full sender and parsed address when rejecting messages
- Test sender normalization to ensure `Oleh Mordach <oleh@get-code.net>` is accepted with allowlist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d5982130832ea117359ab1840a45