### PR TITLE
Handle Gmail attachments and upload to Jira

### DIFF
--- a/README_validations.md
+++ b/README_validations.md
@@ -12,6 +12,8 @@ This repository includes a pytest suite that exercises the core workflows of
   field/label formatting when creating issues.
 * **Firestore state** – reading/writing `last_history_id`, tracking processed
   message IDs with pruning.
+* **Jira attachments** – uploading file and inline image attachments, skipping
+  oversized or disallowed files, and handling partial failures.
 * **Gmail watch renewal** – registering a watch and renewing when expiration is
   near.
 
@@ -36,3 +38,10 @@ docker run --rm -v "$PWD":/app g-ai-j pytest
 
 Configure the CI job to install dependencies and execute `pytest` in the project
 root.  No network access or secrets are required for the tests.
+
+## Environment variables for attachments
+
+* `JIRA_MAX_ATTACHMENT_BYTES` – maximum size of each attachment (default 10MB).
+* `ATTACHMENT_ALLOWED_MIME_JSON` – JSON list of allowed MIME types.
+* `ATTACHMENT_UPLOAD_ENABLED` – set to "false" to disable uploads.
+* `ATTACH_INLINE_IMAGES` – set to "false" to skip inline images.

--- a/src/gaij/app.py
+++ b/src/gaij/app.py
@@ -131,6 +131,12 @@ def process_message(message_id: str) -> None:
     )
 
     if key:
+        attachments = msg.get("attachments", [])
+        results = jira_client.upload_attachments(key, attachments)
+        if results:
+            new_adf = jira_client.build_adf_with_attachment_list(adf, results)
+            if new_adf != adf:
+                jira_client.update_issue_description(key, new_adf)
         firestore_state.mark_processed(message_id)
     else:
         logger.error(

--- a/src/gaij/gmail_client.py
+++ b/src/gaij/gmail_client.py
@@ -3,9 +3,10 @@ import json
 import os
 import re
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, cast
 
 from bs4 import BeautifulSoup
+from bs4.element import Tag
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
@@ -107,10 +108,10 @@ def extract_attachments(message_json: dict[str, Any]) -> list[dict[str, Any]]:
     cid_refs: set[str] = set()
     if html_body:
         soup = BeautifulSoup(html_body, "html.parser")
-        for tag in soup.find_all(src=True):
-            src = tag.get("src", "")
-            if src.startswith("cid:"):
-                cid_refs.add(src[4:])
+        for tag in cast("Iterable[Tag]", soup.find_all(src=True)):
+            src_attr = tag.get("src")
+            if isinstance(src_attr, str) and src_attr.startswith("cid:"):
+                cid_refs.add(src_attr[4:])
 
     attachments: list[dict[str, Any]] = []
     service = None

--- a/src/gaij/settings.py
+++ b/src/gaij/settings.py
@@ -33,6 +33,24 @@ class Settings:
     gcp_firestore_collection: str = os.getenv("GCP_FIRESTORE_COLLECTION", "gaij_state")
     pubsub_topic: str | None = os.getenv("PUBSUB_TOPIC")
 
+    jira_max_attachment_bytes: int = int(
+        os.getenv("JIRA_MAX_ATTACHMENT_BYTES", str(10 * 1024 * 1024))
+    )
+    attachment_allowed_mime_json: list[str] = field(
+        default_factory=lambda: json.loads(
+            os.getenv(
+                "ATTACHMENT_ALLOWED_MIME_JSON",
+                '["application/pdf","image/png","image/jpeg","application/vnd.openxmlformats-officedocument.wordprocessingml.document","application/msword"]',
+            )
+        )
+    )
+    attachment_upload_enabled: bool = (
+        os.getenv("ATTACHMENT_UPLOAD_ENABLED", "true").lower() == "true"
+    )
+    attach_inline_images: bool = (
+        os.getenv("ATTACH_INLINE_IMAGES", "true").lower() == "true"
+    )
+
     openai_api_key: str = os.environ["OPENAI_API_KEY"]
     email_sender: str | None = os.getenv("EMAIL_SENDER")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,21 @@ def firestore_state_module(monkeypatch):
     monkeypatch.setenv("JIRA_PROJECT_KEY", "UIV4")
     monkeypatch.setenv("JIRA_CLIENT_FIELD_ID", "customfield_10000")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("JIRA_MAX_ATTACHMENT_BYTES", "10485760")
+    monkeypatch.setenv(
+        "ATTACHMENT_ALLOWED_MIME_JSON",
+        json.dumps(
+            [
+                "application/pdf",
+                "image/png",
+                "image/jpeg",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "application/msword",
+            ]
+        ),
+    )
+    monkeypatch.setenv("ATTACHMENT_UPLOAD_ENABLED", "true")
+    monkeypatch.setenv("ATTACH_INLINE_IMAGES", "true")
     import gaij.firestore_state as firestore_state
     import gaij.settings as settings
     importlib.reload(settings)
@@ -76,6 +91,21 @@ def app_setup(monkeypatch, firestore_state_module):
     monkeypatch.setenv("JIRA_ASSIGNEE", "assignee@example.com")
     monkeypatch.setenv("JIRA_CLIENT_FIELD_ID", "customfield_10000")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("JIRA_MAX_ATTACHMENT_BYTES", "10485760")
+    monkeypatch.setenv(
+        "ATTACHMENT_ALLOWED_MIME_JSON",
+        json.dumps(
+            [
+                "application/pdf",
+                "image/png",
+                "image/jpeg",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "application/msword",
+            ]
+        ),
+    )
+    monkeypatch.setenv("ATTACHMENT_UPLOAD_ENABLED", "true")
+    monkeypatch.setenv("ATTACH_INLINE_IMAGES", "true")
     domain_map = {"oetraining.com": "OETraining"}
     monkeypatch.setenv("DOMAIN_TO_CLIENT_JSON", json.dumps(domain_map))
 

--- a/tests/test_attachments_file_basic.py
+++ b/tests/test_attachments_file_basic.py
@@ -1,0 +1,62 @@
+import base64
+
+def test_attachments_file_basic(app_setup, monkeypatch):
+    app = app_setup["app"]
+    gmail_client = app_setup["gmail_client"]
+    jira_client = app_setup["jira_client"]
+    gpt_agent = app_setup["gpt_agent"]
+    fs = app_setup["firestore_state"]
+
+    attachments = [
+        {
+            "filename": "file1.pdf",
+            "mime_type": "application/pdf",
+            "data_bytes": b"1",
+            "is_inline": False,
+            "content_id": None,
+        },
+        {
+            "filename": "image.png",
+            "mime_type": "image/png",
+            "data_bytes": b"2",
+            "is_inline": False,
+            "content_id": None,
+        },
+    ]
+
+    monkeypatch.setattr(
+        gmail_client,
+        "get_message",
+        lambda mid: {
+            "from": "Marisa@oetraining.com",
+            "subject": "Sub",
+            "message_id": "<id1>",
+            "body_text": "Body",
+            "attachments": attachments,
+        },
+    )
+    monkeypatch.setattr(gpt_agent, "gpt_classify_issue", lambda s, b: {"issueType": "Task"})
+    monkeypatch.setattr(jira_client, "create_ticket", lambda *a, **k: "JIRA-1")
+
+    uploaded = []
+
+    def fake_post(url, auth=None, headers=None, files=None, timeout=None):
+        uploaded.append(files["file"][0])
+        class R:
+            status_code = 200
+            text = ""
+        return R()
+
+    monkeypatch.setattr(jira_client.requests, "post", fake_post)
+
+    desc = {}
+    monkeypatch.setattr(jira_client, "update_issue_description", lambda k, a: desc.setdefault("adf", a))
+
+    app.process_message("A1")
+
+    assert fs.is_processed("A1")
+    assert set(uploaded) == {"file1.pdf", "image.png"}
+    content = desc["adf"]["content"]
+    assert any(p["content"][0]["text"] == "Attachments" for p in content)
+    assert any(p["content"][0]["text"] == "file1.pdf" for p in content)
+    assert any(p["content"][0]["text"] == "image.png" for p in content)

--- a/tests/test_attachments_inline_images.py
+++ b/tests/test_attachments_inline_images.py
@@ -1,0 +1,85 @@
+import base64
+
+def test_attachments_inline_images(app_setup, monkeypatch):
+    gmail_client = app_setup["gmail_client"]
+    jira_client = app_setup["jira_client"]
+    app = app_setup["app"]
+    gpt_agent = app_setup["gpt_agent"]
+
+    message_json = {
+        "id": "1",
+        "payload": {
+            "mimeType": "multipart/related",
+            "parts": [
+                {
+                    "mimeType": "text/html",
+                    "body": {
+                        "data": base64.urlsafe_b64encode(b'<html><body><img src="cid:abc123"></body></html>').decode()
+                    },
+                },
+                {
+                    "filename": "photo.png",
+                    "mimeType": "image/png",
+                    "body": {"attachmentId": "a1"},
+                    "headers": [{"name": "Content-ID", "value": "<abc123>"}],
+                },
+            ],
+        },
+    }
+
+    class Attachments:
+        def get(self, userId, messageId, id):  # noqa: N803
+            return self
+
+        def execute(self):
+            return {"data": base64.urlsafe_b64encode(b"img").decode()}
+
+    class Messages:
+        def attachments(self):
+            return Attachments()
+
+    class Users:
+        def messages(self):
+            return Messages()
+
+    class Service:
+        def users(self):
+            return Users()
+
+    monkeypatch.setattr(gmail_client, "get_gmail_service", lambda: Service())
+
+    attachments = gmail_client.extract_attachments(message_json)
+    assert attachments[0]["is_inline"]
+
+    monkeypatch.setattr(
+        gmail_client,
+        "get_message",
+        lambda mid: {
+            "from": "Marisa@oetraining.com",
+            "subject": "Sub",
+            "message_id": "<id>",
+            "body_text": "Body",
+            "attachments": attachments,
+        },
+    )
+    monkeypatch.setattr(gpt_agent, "gpt_classify_issue", lambda s, b: {"issueType": "Task"})
+    monkeypatch.setattr(jira_client, "create_ticket", lambda *a, **k: "JIRA-2")
+
+    uploaded = []
+
+    def fake_post(url, auth=None, headers=None, files=None, timeout=None):
+        uploaded.append(files["file"][0])
+        class R:
+            status_code = 200
+            text = ""
+        return R()
+
+    monkeypatch.setattr(jira_client.requests, "post", fake_post)
+    desc = {}
+    monkeypatch.setattr(jira_client, "update_issue_description", lambda k, a: desc.setdefault("adf", a))
+
+    app.process_message("A1")
+
+    assert set(uploaded) == {"photo.png"}
+    content = desc["adf"]["content"]
+    assert any(p["content"][0]["text"] == "photo.png" for p in content)

--- a/tests/test_attachments_mime_filter.py
+++ b/tests/test_attachments_mime_filter.py
@@ -1,0 +1,58 @@
+
+def test_attachments_mime_filter(app_setup, monkeypatch):
+    app = app_setup["app"]
+    gmail_client = app_setup["gmail_client"]
+    jira_client = app_setup["jira_client"]
+    gpt_agent = app_setup["gpt_agent"]
+
+    attachments = [
+        {
+            "filename": "doc.pdf",
+            "mime_type": "application/pdf",
+            "data_bytes": b"1",
+            "is_inline": False,
+            "content_id": None,
+        },
+        {
+            "filename": "img.png",
+            "mime_type": "image/png",
+            "data_bytes": b"2",
+            "is_inline": False,
+            "content_id": None,
+        },
+    ]
+
+    monkeypatch.setattr(
+        gmail_client,
+        "get_message",
+        lambda mid: {
+            "from": "Marisa@oetraining.com",
+            "subject": "Sub",
+            "message_id": "<id>",
+            "body_text": "Body",
+            "attachments": attachments,
+        },
+    )
+    monkeypatch.setattr(gpt_agent, "gpt_classify_issue", lambda s, b: {"issueType": "Task"})
+    monkeypatch.setattr(jira_client, "create_ticket", lambda *a, **k: "JIRA-4")
+    monkeypatch.setattr(jira_client.settings, "attachment_allowed_mime_json", ["application/pdf"])
+
+    uploaded = []
+
+    def fake_post(url, auth=None, headers=None, files=None, timeout=None):
+        uploaded.append(files["file"][0])
+        class R:
+            status_code = 200
+            text = ""
+        return R()
+
+    monkeypatch.setattr(jira_client.requests, "post", fake_post)
+    desc = {}
+    monkeypatch.setattr(jira_client, "update_issue_description", lambda k, a: desc.setdefault("adf", a))
+
+    app.process_message("A1")
+
+    assert uploaded == ["doc.pdf"]
+    content = desc["adf"]["content"]
+    assert any(p["content"][0]["text"] == "doc.pdf" for p in content)
+    assert all("img.png" not in p["content"][0]["text"] for p in content if p.get("content"))

--- a/tests/test_attachments_no_duplicates_for_processed_message.py
+++ b/tests/test_attachments_no_duplicates_for_processed_message.py
@@ -1,0 +1,32 @@
+
+def test_attachments_no_duplicates_for_processed_message(app_setup, monkeypatch):
+    app = app_setup["app"]
+    gmail_client = app_setup["gmail_client"]
+    jira_client = app_setup["jira_client"]
+    fs = app_setup["firestore_state"]
+
+    fs.mark_processed("A1")
+
+    called = {"ticket": False, "upload": False, "get": False}
+
+    def fake_get(mid):
+        called["get"] = True
+        return {}
+
+    def fake_ticket(*a, **k):
+        called["ticket"] = True
+        return "JIRA-5"
+
+    def fake_upload(*a, **k):
+        called["upload"] = True
+        return {}
+
+    monkeypatch.setattr(gmail_client, "get_message", fake_get)
+    monkeypatch.setattr(jira_client, "create_ticket", fake_ticket)
+    monkeypatch.setattr(jira_client, "upload_attachments", fake_upload)
+
+    app.process_message("A1")
+
+    assert called["get"] is False
+    assert called["ticket"] is False
+    assert called["upload"] is False

--- a/tests/test_attachments_skip_oversize.py
+++ b/tests/test_attachments_skip_oversize.py
@@ -1,0 +1,60 @@
+
+def test_attachments_skip_oversize(app_setup, monkeypatch, caplog):
+    app = app_setup["app"]
+    gmail_client = app_setup["gmail_client"]
+    jira_client = app_setup["jira_client"]
+    gpt_agent = app_setup["gpt_agent"]
+
+    attachments = [
+        {
+            "filename": "big.pdf",
+            "mime_type": "application/pdf",
+            "data_bytes": b"1234567",
+            "is_inline": False,
+            "content_id": None,
+        },
+        {
+            "filename": "small.pdf",
+            "mime_type": "application/pdf",
+            "data_bytes": b"1",
+            "is_inline": False,
+            "content_id": None,
+        },
+    ]
+
+    monkeypatch.setattr(
+        gmail_client,
+        "get_message",
+        lambda mid: {
+            "from": "Marisa@oetraining.com",
+            "subject": "Sub",
+            "message_id": "<id>",
+            "body_text": "Body",
+            "attachments": attachments,
+        },
+    )
+    monkeypatch.setattr(gpt_agent, "gpt_classify_issue", lambda s, b: {"issueType": "Task"})
+    monkeypatch.setattr(jira_client, "create_ticket", lambda *a, **k: "JIRA-3")
+    monkeypatch.setattr(jira_client.settings, "jira_max_attachment_bytes", 5)
+
+    uploaded = []
+
+    def fake_post(url, auth=None, headers=None, files=None, timeout=None):
+        uploaded.append(files["file"][0])
+        class R:
+            status_code = 200
+            text = ""
+        return R()
+
+    monkeypatch.setattr(jira_client.requests, "post", fake_post)
+    desc = {}
+    monkeypatch.setattr(jira_client, "update_issue_description", lambda k, a: desc.setdefault("adf", a))
+
+    with caplog.at_level("WARNING"):
+        app.process_message("A1")
+
+    assert uploaded == ["small.pdf"]
+    assert "oversize attachment" in caplog.text
+    content = desc["adf"]["content"]
+    assert any(p["content"][0]["text"] == "small.pdf" for p in content)
+    assert all("big.pdf" not in p["content"][0]["text"] for p in content if p.get("content"))

--- a/tests/test_end_to_end_pubsub_payload_with_attachments.py
+++ b/tests/test_end_to_end_pubsub_payload_with_attachments.py
@@ -1,0 +1,52 @@
+
+def test_end_to_end_pubsub_payload_with_attachments(app_setup, pubsub_envelope, monkeypatch):
+    client = app_setup["client"]
+    gmail_client = app_setup["gmail_client"]
+    jira_client = app_setup["jira_client"]
+    gpt_agent = app_setup["gpt_agent"]
+    fs = app_setup["firestore_state"]
+
+    attachments = [
+        {
+            "filename": "doc.pdf",
+            "mime_type": "application/pdf",
+            "data_bytes": b"1",
+            "is_inline": False,
+            "content_id": None,
+        }
+    ]
+
+    monkeypatch.setattr(gmail_client, "list_new_message_ids_since", lambda s, e: ["A1"])
+    monkeypatch.setattr(
+        gmail_client,
+        "get_message",
+        lambda mid: {
+            "from": "Marisa@oetraining.com",
+            "subject": "Sub",
+            "message_id": "<id>",
+            "body_text": "Body",
+            "attachments": attachments,
+        },
+    )
+    monkeypatch.setattr(gpt_agent, "gpt_classify_issue", lambda s, b: {"issueType": "Task"})
+    monkeypatch.setattr(jira_client, "create_ticket", lambda *a, **k: "JIRA-7")
+
+    uploaded = []
+
+    def fake_post(url, auth=None, headers=None, files=None, timeout=None):
+        uploaded.append(files["file"][0])
+        class R:
+            status_code = 200
+            text = ""
+        return R()
+
+    monkeypatch.setattr(jira_client.requests, "post", fake_post)
+    desc = {}
+    monkeypatch.setattr(jira_client, "update_issue_description", lambda k, a: desc.setdefault("adf", a))
+
+    res = client.post("/pubsub", json=pubsub_envelope)
+    assert res.status_code == 204
+    assert fs.is_processed("A1")
+    assert uploaded == ["doc.pdf"]
+    content = desc["adf"]["content"]
+    assert any(p["content"][0]["text"] == "doc.pdf" for p in content)

--- a/tests/test_gpt_agent_and_utils.py
+++ b/tests/test_gpt_agent_and_utils.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+
+def test_gpt_classify_issue_success(monkeypatch, app_setup):
+    gpt_agent = app_setup["gpt_agent"]
+
+    dummy_resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content='{"issueType":"Bug","client":"ClientX"}'))]
+    )
+
+    monkeypatch.setattr(
+        gpt_agent.client.chat.completions, "create", lambda **kwargs: dummy_resp
+    )
+
+    result = gpt_agent.gpt_classify_issue("subj", "body")
+    assert result == {"issueType": "Bug", "client": "ClientX"}
+
+
+def test_gpt_classify_issue_failure(monkeypatch, app_setup):
+    gpt_agent = app_setup["gpt_agent"]
+
+    def raise_exc(**kwargs):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(gpt_agent.client.chat.completions, "create", raise_exc)
+    assert gpt_agent.gpt_classify_issue("s", "b") is None
+
+
+def test_extract_history_id_invalid(app_setup):
+    app = app_setup["app"]
+    assert app.extract_history_id({}) is None
+    assert app.extract_history_id({"historyId": "abc"}) is None

--- a/tests/test_jira_upload_failure_partial.py
+++ b/tests/test_jira_upload_failure_partial.py
@@ -1,0 +1,60 @@
+
+def test_jira_upload_failure_partial(app_setup, monkeypatch):
+    app = app_setup["app"]
+    gmail_client = app_setup["gmail_client"]
+    jira_client = app_setup["jira_client"]
+    gpt_agent = app_setup["gpt_agent"]
+    fs = app_setup["firestore_state"]
+
+    attachments = [
+        {
+            "filename": "good.pdf",
+            "mime_type": "application/pdf",
+            "data_bytes": b"1",
+            "is_inline": False,
+            "content_id": None,
+        },
+        {
+            "filename": "bad.pdf",
+            "mime_type": "application/pdf",
+            "data_bytes": b"2",
+            "is_inline": False,
+            "content_id": None,
+        },
+    ]
+
+    monkeypatch.setattr(
+        gmail_client,
+        "get_message",
+        lambda mid: {
+            "from": "Marisa@oetraining.com",
+            "subject": "Sub",
+            "message_id": "<id>",
+            "body_text": "Body",
+            "attachments": attachments,
+        },
+    )
+    monkeypatch.setattr(gpt_agent, "gpt_classify_issue", lambda s, b: {"issueType": "Task"})
+    monkeypatch.setattr(jira_client, "create_ticket", lambda *a, **k: "JIRA-6")
+
+    uploaded = []
+
+    def fake_post(url, auth=None, headers=None, files=None, timeout=None):
+        name = files["file"][0]
+        uploaded.append(name)
+        class R:
+            text = ""
+            status_code = 200 if name == "good.pdf" else 400
+        return R()
+
+    monkeypatch.setattr(jira_client.requests, "post", fake_post)
+    desc = {}
+    monkeypatch.setattr(jira_client, "update_issue_description", lambda k, a: desc.setdefault("adf", a))
+
+    app.process_message("A1")
+
+    assert fs.is_processed("A1")
+    assert uploaded == ["good.pdf", "bad.pdf"]
+    content = desc["adf"]["content"]
+    assert any(p["content"][0]["text"] == "good.pdf" for p in content)
+    assert all("bad.pdf" not in p["content"][0]["text"] for p in content if p.get("content"))


### PR DESCRIPTION
## Summary
- extract Gmail file and inline attachments with safe filenames
- upload attachments to Jira issues and note successes in description
- document attachment env vars and add extensive tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c3111164832e8d903eaae02b9e05