### PR TITLE
Fix duplicate Jira tickets from one email

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 from google.cloud import firestore as firestore_mod
+from google.api_core import exceptions as gcloud_exceptions
 
 # Ensure the repository root is on the import path so application modules can
 # be imported when tests run from the `tests/` directory.
@@ -27,6 +28,14 @@ class FakeDocument:
 
     def set(self, data):
         self.store[self.path] = data
+
+    def create(self, data):
+        if self.path in self.store:
+            raise gcloud_exceptions.AlreadyExists("Document already exists")
+        self.store[self.path] = data
+
+    def delete(self):
+        self.store.pop(self.path, None)
 
     def collection(self, name):
         return FakeCollection(self.store, f"{self.path}/{name}")

--- a/tests/test_concurrent_processing.py
+++ b/tests/test_concurrent_processing.py
@@ -1,0 +1,40 @@
+import threading
+
+def test_concurrent_processing_creates_single_ticket(app_setup, monkeypatch):
+    app = app_setup["app"]
+    jira_client = app_setup["jira_client"]
+    gmail_client = app_setup["gmail_client"]
+    gpt_agent = app_setup["gpt_agent"]
+
+    message = {
+        "from": "Marisa@oetraining.com",
+        "subject": "Sub",
+        "message_id": "<id1>",
+        "body_text": "Body",
+        "body_html": "<p>Body</p>",
+        "inline_map": {},
+        "inline_parts": [],
+        "attachments": [],
+    }
+
+    monkeypatch.setattr(gmail_client, "get_message", lambda mid: message)
+    monkeypatch.setattr(gpt_agent, "gpt_classify_issue", lambda s, b: {"issueType": "Task"})
+
+    created = []
+    monkeypatch.setattr(
+        jira_client,
+        "create_ticket",
+        lambda *a, **k: created.append("JIRA-1") or "JIRA-1",
+    )
+
+    def run():
+        app.process_message("A1")
+
+    t1 = threading.Thread(target=run)
+    t2 = threading.Thread(target=run)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert created == ["JIRA-1"]


### PR DESCRIPTION
## Summary
- prevent concurrent processing of the same Gmail message
- add Firestore message claim/unclaim helpers
- cover concurrency with new test

## Testing
- `pytest tests/test_concurrent_processing.py -q`
- `pytest -q`
- ⚠️ `pre-commit run --files tests/conftest.py src/gaij/firestore_state.py src/gaij/app.py tests/test_concurrent_processing.py` *(missing dependency: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68a970dbae64832e9acb92f3d9ae3b6d