### PR TITLE
feat: embed inline images into Jira descriptions

### DIFF
--- a/src/gaij/jira_client.py
+++ b/src/gaij/jira_client.py
@@ -66,43 +66,53 @@ def _upload_one_attachment(
     allowed: set[str],
     max_bytes: int,
     issue_key: str,
-) -> tuple[str, str]:
-    """Return (filename, status) after attempting a single upload."""
+    ) -> tuple[str, str, Optional[str]]:
+    """Return ``(filename, status, attachment_id)`` after attempting upload."""
     name = att.get("filename", "attachment")
     data = att.get("data_bytes", b"")
     mime = att.get("mime_type", "application/octet-stream")
 
     if att.get("is_inline") and not settings.attach_inline_images:
         logger.info("Skipping inline attachment %s", name)
-        return name, "skipped inline"
+        return name, "skipped inline", None
     if len(data) > max_bytes:
         logger.warning("Skipping oversize attachment %s", name)
-        return name, "oversize"
+        return name, "oversize", None
     if allowed and mime not in allowed:
         logger.warning("Skipping disallowed attachment %s", name)
-        return name, "disallowed"
+        return name, "disallowed", None
 
     files = {"file": (name, data, mime)}
     try:
         resp = requests.post(url, auth=auth, headers=headers, files=files, timeout=10)
     except requests.RequestException as exc:
         logger.error("Error uploading attachment %s: %s", name, exc)
-        return name, "error"
+        return name, "error", None
 
     if resp.status_code in (200, 201):
+        attach_id: Optional[str] = None
+        try:
+            data = resp.json()
+            if isinstance(data, list) and data:
+                attach_id = str(data[0].get("id"))
+        except Exception:  # pragma: no cover - best effort
+            attach_id = None
         logger.info("Uploaded attachment %s to %s", name, issue_key)
-        return name, "uploaded"
+        return name, "uploaded", attach_id
     logger.error(
         "Failed to upload attachment %s: %s %s", name, resp.status_code, resp.text
     )
-    return name, f"failed {resp.status_code}"
+    return name, f"failed {resp.status_code}", None
 
 
-def upload_attachments(issue_key: str, attachments: list[dict[str, Any]]) -> dict[str, str]:
-    """Upload attachments to a Jira issue and return per-file results."""
+def upload_attachments(
+    issue_key: str, attachments: list[dict[str, Any]]
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Upload attachments and return status plus ``cid/filename → id`` map."""
     results: dict[str, str] = {}
+    id_map: dict[str, str] = {}
     if not settings.attachment_upload_enabled or not attachments:
-        return results
+        return results, id_map
 
     url = f"{settings.jira_url}/rest/api/3/issue/{issue_key}/attachments"
     auth = HTTPBasicAuth(settings.jira_user, settings.jira_api_token)
@@ -111,11 +121,14 @@ def upload_attachments(issue_key: str, attachments: list[dict[str, Any]]) -> dic
     max_bytes = settings.jira_max_attachment_bytes
 
     for att in attachments:
-        name, status = _upload_one_attachment(
+        name, status, attach_id = _upload_one_attachment(
             att, url, auth, headers, allowed, max_bytes, issue_key
         )
         results[name] = status
-    return results
+        if attach_id:
+            key = att.get("content_id") or name
+            id_map[str(key)] = attach_id
+    return results, id_map
 
 
 def build_adf_with_attachment_list(

--- a/tests/test_attachment_filters_and_limits.py
+++ b/tests/test_attachment_filters_and_limits.py
@@ -47,10 +47,14 @@ def test_attachment_filters_and_limits(app_setup, monkeypatch):
     uploaded = []
 
     def fake_post(url, auth=None, headers=None, files=None, timeout=None):
-        uploaded.append(files["file"][0])
+        name = files["file"][0]
+        uploaded.append(name)
+        idx = len(uploaded)
         class R:
             status_code = 200
             text = ""
+            def json(self):
+                return [{"id": str(idx)}]
         return R()
 
     monkeypatch.setattr(jira_client.requests, "post", fake_post)

--- a/tests/test_dedupe_no_reupload.py
+++ b/tests/test_dedupe_no_reupload.py
@@ -25,10 +25,14 @@ def test_dedupe_no_reupload(app_setup, monkeypatch):
     uploaded = []
 
     def fake_post(url, auth=None, headers=None, files=None, timeout=None):
-        uploaded.append(files["file"][0])
+        name = files["file"][0]
+        uploaded.append(name)
+        idx = len(uploaded)
         class R:
             status_code = 200
             text = ""
+            def json(self):
+                return [{"id": str(idx)}]
         return R()
 
     monkeypatch.setattr(jira_client.requests, "post", fake_post)

--- a/tests/test_file_attachments_upload.py
+++ b/tests/test_file_attachments_upload.py
@@ -38,10 +38,14 @@ def test_file_attachments_upload(app_setup, monkeypatch):
     uploaded = []
 
     def fake_post(url, auth=None, headers=None, files=None, timeout=None):
-        uploaded.append(files["file"][0])
+        name = files["file"][0]
+        uploaded.append(name)
+        idx = len(uploaded)
         class R:
             status_code = 200
             text = ""
+            def json(self):
+                return [{"id": str(idx)}]
         return R()
 
     monkeypatch.setattr(jira_client.requests, "post", fake_post)

--- a/tests/test_inline_images_cid_mapping.py
+++ b/tests/test_inline_images_cid_mapping.py
@@ -33,3 +33,10 @@ def test_inline_images_cid_mapping(app_setup):
     adf = build_adf_from_html(html, inline_map)
     text_nodes = [n.get("text") for p in adf["content"] for n in p.get("content", [])]
     assert any(t and t.startswith("[inline image: photo.png]") for t in text_nodes)
+
+
+def test_inline_images_render_with_ids():
+    html = "<html><body><img src='__INLINE_IMAGE__[abc]__'></body></html>"
+    adf = build_adf_from_html(html, {"abc": "123"})
+    media_nodes = [n for n in adf["content"] if n.get("type") == "mediaSingle"]
+    assert media_nodes[0]["content"][0]["attrs"]["id"] == "123"

--- a/tests/test_jira_client_edge_cases.py
+++ b/tests/test_jira_client_edge_cases.py
@@ -26,6 +26,8 @@ def test_upload_attachments_inline_and_error(monkeypatch, app_setup):
         class R:
             status_code = 200
             text = ""
+            def json(self):
+                return [{"id": "1"}]
         return R()
 
     monkeypatch.setattr(jira_client.requests, "post", fake_post)
@@ -45,9 +47,10 @@ def test_upload_attachments_inline_and_error(monkeypatch, app_setup):
             "content_id": None,
         },
     ]
-    results = jira_client.upload_attachments("JIRA-1", attachments)
+    results, id_map = jira_client.upload_attachments("JIRA-1", attachments)
     assert results["inline.png"] == "skipped inline"
     assert results["error.png"] == "error"
+    assert id_map == {}
 
 
 def test_update_issue_description_error(monkeypatch, app_setup):

--- a/tests/test_jira_upload_failure_partial.py
+++ b/tests/test_jira_upload_failure_partial.py
@@ -49,6 +49,8 @@ def test_jira_upload_failure_partial(app_setup, monkeypatch):
         class R:
             text = ""
             status_code = 200 if name == "good.pdf" else 400
+            def json(self):
+                return [{"id": "1"}]
         return R()
 
     monkeypatch.setattr(jira_client.requests, "post", fake_post)

--- a/tests/test_render_full_fidelity_pdf.py
+++ b/tests/test_render_full_fidelity_pdf.py
@@ -59,10 +59,14 @@ def test_render_full_fidelity_pdf_integration(app_setup, monkeypatch):
     uploaded = []
 
     def fake_post(url, auth=None, headers=None, files=None, timeout=None):
-        uploaded.append(files["file"][0])
+        name = files["file"][0]
+        uploaded.append(name)
+        idx = len(uploaded)
         class R:
             status_code = 200
             text = ""
+            def json(self):
+                return [{"id": str(idx)}]
         return R()
 
     monkeypatch.setattr(jira_client.requests, "post", fake_post)


### PR DESCRIPTION
## Summary
- capture Jira attachment IDs during upload and track them by filename or CID
- render inline images as ADF media nodes referencing uploaded attachment IDs
- rebuild Jira descriptions with inline media and attachment list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9798eb474832eb355bd6255d2e589