### PR TITLE
fix: generate valid email PDF

### DIFF
--- a/src/gaij/html_renderer.py
+++ b/src/gaij/html_renderer.py
@@ -1,14 +1,60 @@
+"""Utilities to render e‑mail HTML into shareable artifacts."""
+
+from __future__ import annotations
+
 import base64
 from typing import Any
 
+from bs4 import BeautifulSoup
 
-def render_html(html: str, inline_parts: list[dict[str, Any]], fmt: str = "pdf") -> tuple[bytes, str]:
-    """Render HTML to PDF/PNG bytes embedding inline images.
 
-    This is a lightweight stand-in for real rendering libraries. It simply
-    replaces ``cid:`` references with data URIs and returns the resulting HTML
-    encoded as bytes with a fake PDF/PNG header so tests can assert output
-    exists without heavy dependencies.
+def _simple_pdf_bytes(text: str) -> bytes:
+    """Create a very small but valid PDF containing ``text``.
+
+    The implementation avoids external dependencies so it can run in the
+    constrained execution environment used for tests.  The generated PDF uses
+    a single page with the built‑in Helvetica font.
+    """
+
+    # Escape characters that have a special meaning in PDF text objects.
+    esc = text.replace("\\", r"\\\\").replace("(", r"\\(").replace(")", r"\\)")
+    content = f"BT /F1 12 Tf 72 720 Td ({esc}) Tj ET"
+
+    objects: list[str] = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        (
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            "/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>"
+        ),
+        f"<< /Length {len(content)} >>\nstream\n{content}\nendstream",
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+
+    pdf = bytearray(b"%PDF-1.4\n")
+    offsets = [0]
+    for i, obj in enumerate(objects, start=1):
+        offsets.append(len(pdf))
+        pdf.extend(f"{i} 0 obj\n{obj}\nendobj\n".encode("latin-1"))
+    xref = len(pdf)
+    pdf.extend(f"xref\n0 {len(objects)+1}\n0000000000 65535 f \n".encode("latin-1"))
+    for off in offsets[1:]:
+        pdf.extend(f"{off:010d} 00000 n \n".encode("latin-1"))
+    pdf.extend(b"trailer\n")
+    pdf.extend(f"<< /Size {len(objects)+1} /Root 1 0 R >>\n".encode("latin-1"))
+    pdf.extend(f"startxref\n{xref}\n%%EOF".encode("latin-1"))
+    return bytes(pdf)
+
+
+def render_html(
+    html: str, inline_parts: list[dict[str, Any]], fmt: str = "pdf"
+) -> tuple[bytes, str]:
+    """Render HTML e‑mail to PDF/PNG bytes embedding inline images.
+
+    ``fmt`` currently supports ``"pdf"`` and ``"png"`` (the latter remains a
+    lightweight placeholder).  Inline images referenced via ``cid:`` URLs are
+    replaced with base64 ``data:`` URIs so that the rendered output is
+    self‑contained.
     """
 
     for part in inline_parts:
@@ -17,8 +63,14 @@ def render_html(html: str, inline_parts: list[dict[str, Any]], fmt: str = "pdf")
         mime = part.get("mime_type", "application/octet-stream")
         if cid:
             html = html.replace(f"cid:{cid}", f"data:{mime};base64,{data.decode()}")
+
     if fmt == "png":
         filename = "email-render.png"
         return b"PNGFAKE" + html.encode("utf-8"), filename
+
+    # Convert HTML to plain text for the minimal PDF representation.
+    soup = BeautifulSoup(html, "html.parser")
+    text = soup.get_text(separator="\n")
+    pdf_bytes = _simple_pdf_bytes(text)
     filename = "email-render.pdf"
-    return b"%PDF-FAKE\n" + html.encode("utf-8"), filename
+    return pdf_bytes, filename

--- a/src/gaij/html_renderer.py
+++ b/src/gaij/html_renderer.py
@@ -1,4 +1,4 @@
-"""Utilities to render e‑mail HTML into shareable artifacts."""
+"""Utilities to render e-mail HTML into shareable artifacts."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ def _simple_pdf_bytes(text: str) -> bytes:
 
     The implementation avoids external dependencies so it can run in the
     constrained execution environment used for tests.  The generated PDF uses
-    a single page with the built‑in Helvetica font.
+    a single page with the built-in Helvetica font.
     """
 
     # Escape characters that have a special meaning in PDF text objects.
@@ -49,12 +49,12 @@ def _simple_pdf_bytes(text: str) -> bytes:
 def render_html(
     html: str, inline_parts: list[dict[str, Any]], fmt: str = "pdf"
 ) -> tuple[bytes, str]:
-    """Render HTML e‑mail to PDF/PNG bytes embedding inline images.
+    """Render HTML e-mail to PDF/PNG bytes embedding inline images.
 
     ``fmt`` currently supports ``"pdf"`` and ``"png"`` (the latter remains a
     lightweight placeholder).  Inline images referenced via ``cid:`` URLs are
     replaced with base64 ``data:`` URIs so that the rendered output is
-    self‑contained.
+    self-contained.
     """
 
     for part in inline_parts:

--- a/tests/test_render_full_fidelity_pdf.py
+++ b/tests/test_render_full_fidelity_pdf.py
@@ -16,7 +16,9 @@ def test_render_full_fidelity_pdf_unit():
     ]
     pdf_bytes, name = render_html(html, inline_parts, "pdf")
     assert name.endswith(".pdf")
-    assert pdf_bytes.startswith(b"%PDF-FAKE")
+    # Real PDFs must start with the "%PDF-" header and terminate with "%%EOF".
+    assert pdf_bytes.startswith(b"%PDF-")
+    assert pdf_bytes.strip().endswith(b"%%EOF")
 
 
 def test_render_full_fidelity_pdf_integration(app_setup, monkeypatch):


### PR DESCRIPTION
## Summary
- build a minimal PDF renderer so email-render.pdf is a valid document
- sanitize inline images and convert HTML to text before embedding in PDF
- assert produced PDFs have proper header and EOF markers

## Testing
- `pytest`
- `pre-commit run --files src/gaij/html_renderer.py tests/test_render_full_fidelity_pdf.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a97e775f54832ea61c9a21d8fb5ab5