### PR TITLE
Handle Unicode in PDF rendering to avoid latin-1 errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ line-length = 100
 
 [tool.ruff]
 line-length = 100
+
+[tool.ruff.lint]
 select = ["I", "UP", "B", "C4", "SIM", "N", "RUF"]
 
 [tool.mypy]

--- a/src/gaij/html_renderer.py
+++ b/src/gaij/html_renderer.py
@@ -35,14 +35,20 @@ def _simple_pdf_bytes(text: str) -> bytes:
     offsets = [0]
     for i, obj in enumerate(objects, start=1):
         offsets.append(len(pdf))
-        pdf.extend(f"{i} 0 obj\n{obj}\nendobj\n".encode("latin-1"))
+        pdf.extend(f"{i} 0 obj\n{obj}\nendobj\n".encode("latin-1", "replace"))
     xref = len(pdf)
-    pdf.extend(f"xref\n0 {len(objects)+1}\n0000000000 65535 f \n".encode("latin-1"))
+    pdf.extend(
+        f"xref\n0 {len(objects)+1}\n0000000000 65535 f \n".encode(
+            "latin-1", "replace"
+        )
+    )
     for off in offsets[1:]:
-        pdf.extend(f"{off:010d} 00000 n \n".encode("latin-1"))
+        pdf.extend(f"{off:010d} 00000 n \n".encode("latin-1", "replace"))
     pdf.extend(b"trailer\n")
-    pdf.extend(f"<< /Size {len(objects)+1} /Root 1 0 R >>\n".encode("latin-1"))
-    pdf.extend(f"startxref\n{xref}\n%%EOF".encode("latin-1"))
+    pdf.extend(
+        f"<< /Size {len(objects)+1} /Root 1 0 R >>\n".encode("latin-1", "replace")
+    )
+    pdf.extend(f"startxref\n{xref}\n%%EOF".encode("latin-1", "replace"))
     return bytes(pdf)
 
 

--- a/src/gaij/jira_client.py
+++ b/src/gaij/jira_client.py
@@ -65,7 +65,7 @@ def _attachment_skip_reason(
     mime: str,
     allowed: set[str],
     max_bytes: int,
-) -> Optional[str]:
+) -> str | None:
     """Return a skip status if the attachment should not be uploaded."""
     if att.get("is_inline") and not settings.attach_inline_images:
         logger.info("Skipping inline attachment %s", name)
@@ -79,7 +79,7 @@ def _attachment_skip_reason(
     return None
 
 
-def _extract_attachment_id(resp: requests.Response) -> Optional[str]:
+def _extract_attachment_id(resp: requests.Response) -> str | None:
     """Best-effort extraction of the attachment ID from the response."""
     try:
         data = resp.json()
@@ -98,7 +98,7 @@ def _upload_one_attachment(
     allowed: set[str],
     max_bytes: int,
     issue_key: str,
-) -> tuple[str, str, Optional[str]]:
+) -> tuple[str, str, str | None]:
     """Return ``(filename, status, attachment_id)`` after attempting upload."""
     name = att.get("filename", "attachment")
     data = att.get("data_bytes", b"")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ import sys
 from types import SimpleNamespace
 
 import pytest
-from google.cloud import firestore as firestore_mod
 from google.api_core import exceptions as gcloud_exceptions
+from google.cloud import firestore as firestore_mod
 
 # Ensure the repository root is on the import path so application modules can
 # be imported when tests run from the `tests/` directory.

--- a/tests/test_concurrent_processing.py
+++ b/tests/test_concurrent_processing.py
@@ -1,5 +1,6 @@
 import threading
 
+
 def test_concurrent_processing_creates_single_ticket(app_setup, monkeypatch):
     app = app_setup["app"]
     jira_client = app_setup["jira_client"]

--- a/tests/test_render_full_fidelity_pdf.py
+++ b/tests/test_render_full_fidelity_pdf.py
@@ -21,6 +21,14 @@ def test_render_full_fidelity_pdf_unit():
     assert pdf_bytes.strip().endswith(b"%%EOF")
 
 
+def test_render_pdf_handles_unicode():
+    html = "<p>Unicode\u202ftext – 😊</p>"
+    pdf_bytes, name = render_html(html, [], "pdf")
+    assert name.endswith(".pdf")
+    assert pdf_bytes.startswith(b"%PDF-")
+    assert pdf_bytes.strip().endswith(b"%%EOF")
+
+
 def test_render_full_fidelity_pdf_integration(app_setup, monkeypatch):
     app = app_setup["app"]
     gmail_client = app_setup["gmail_client"]

--- a/tests/test_render_full_fidelity_pdf.py
+++ b/tests/test_render_full_fidelity_pdf.py
@@ -22,7 +22,7 @@ def test_render_full_fidelity_pdf_unit():
 
 
 def test_render_pdf_handles_unicode():
-    html = "<p>Unicode\u202ftext – 😊</p>"
+    html = "<p>Unicode\u202ftext - 😊</p>"
     pdf_bytes, name = render_html(html, [], "pdf")
     assert name.endswith(".pdf")
     assert pdf_bytes.startswith(b"%PDF-")


### PR DESCRIPTION
## Summary
- tolerate non-Latin characters when creating minimal PDF artifacts
- test pdf rendering with Unicode text

## Testing
- `pre-commit run --files src/gaij/html_renderer.py tests/test_render_full_fidelity_pdf.py` *(failed: command not found: pre-commit)*
- `pip install pre-commit` *(failed: Could not connect to proxy: Tunnel connection failed: 403 Forbidden)*
- `pytest tests/test_render_full_fidelity_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_68a98738da0c832e9107840dbd3437d4