### PR TITLE
Preserve email formatting and line breaks

### DIFF
--- a/src/gaij/html_renderer.py
+++ b/src/gaij/html_renderer.py
@@ -76,6 +76,9 @@ def render_html(
 
     # Convert HTML to plain text for the minimal PDF representation.
     soup = BeautifulSoup(html, "html.parser")
+    # Preserve explicit line breaks to keep e-mail formatting readable.
+    for br in soup.find_all("br"):
+        br.replace_with("\n")
     text = soup.get_text(separator="\n")
     pdf_bytes = _simple_pdf_bytes(text)
     filename = "email-render.pdf"

--- a/src/gaij/html_renderer.py
+++ b/src/gaij/html_renderer.py
@@ -6,6 +6,7 @@ import base64
 from typing import Any
 
 from bs4 import BeautifulSoup
+from bs4.element import NavigableString
 
 
 def _simple_pdf_bytes(text: str) -> bytes:
@@ -78,7 +79,7 @@ def render_html(
     soup = BeautifulSoup(html, "html.parser")
     # Preserve explicit line breaks to keep e-mail formatting readable.
     for br in soup.find_all("br"):
-        br.replace_with("\n")
+        br.replace_with(NavigableString("\n"))
     text = soup.get_text(separator="\n")
     pdf_bytes = _simple_pdf_bytes(text)
     filename = "email-render.pdf"

--- a/src/gaij/html_to_adf.py
+++ b/src/gaij/html_to_adf.py
@@ -44,11 +44,28 @@ def _convert_inline(
 
     if isinstance(node, Tag):
         name = node.name.lower()
+        if name == "br":
+            # Represent <br> as a hard break within the paragraph.
+            return [{"type": "hardBreak"}]
+
         new_marks = marks + ([MARK_TAGS[name]] if name in MARK_TAGS else [])
+
+        # Support basic inline styles such as <span style="font-weight:bold">.
+        style_attr = node.get("style", "")
+        if isinstance(style_attr, str):
+            style = style_attr.lower()
+            if "font-weight" in style and "bold" in style:
+                new_marks.append({"type": "strong"})
+            if "font-style" in style and "italic" in style:
+                new_marks.append({"type": "em"})
+            if "text-decoration" in style and "underline" in style:
+                new_marks.append({"type": "underline"})
+
         if name == "a":
             href_attr = node.get("href")
             href = href_attr if isinstance(href_attr, str) else ""
             new_marks.append({"type": "link", "attrs": {"href": href}})
+
         result: list[dict[str, Any]] = []
         for child in node.children:
             result.extend(_convert_inline(child, inline_map, new_marks))

--- a/tests/test_html_renderer_linebreaks.py
+++ b/tests/test_html_renderer_linebreaks.py
@@ -1,0 +1,8 @@
+from gaij.html_renderer import render_html
+
+
+def test_render_html_preserves_linebreaks_in_pdf():
+    html = "<p>Line1<br>Line2</p>"
+    pdf_bytes, name = render_html(html, [], fmt="pdf")
+    assert name.endswith(".pdf")
+    assert b"Line1" in pdf_bytes and b"Line2" in pdf_bytes

--- a/tests/test_html_to_adf_styles_and_breaks.py
+++ b/tests/test_html_to_adf_styles_and_breaks.py
@@ -1,0 +1,19 @@
+from gaij.html_to_adf import build_adf_from_html
+
+
+def test_html_to_adf_handles_span_styles_and_line_breaks():
+    html = (
+        "<p>Line1<br>Line2"
+        "<span style='font-weight:bold'>B</span>"
+        "<span style='font-style:italic'>I</span>"
+        "<span style='text-decoration:underline'>U</span>"
+        "</p>"
+    )
+    adf = build_adf_from_html(html, {})
+    para = adf["content"][0]
+    nodes = para["content"]
+    assert nodes[1]["type"] == "hardBreak"
+    assert nodes[2]["text"] == "Line2"
+    assert any(m["type"] == "strong" for m in nodes[3].get("marks", []))
+    assert any(m["type"] == "em" for m in nodes[4].get("marks", []))
+    assert any(m["type"] == "underline" for m in nodes[5].get("marks", []))


### PR DESCRIPTION
## Summary
- Handle `<br>` tags and inline styles when converting HTML to Atlassian Document Format
- Keep line breaks when rendering HTML to PDF so email formatting is preserved
- Add regression tests for span style marks and line-break rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a99378a4ec832e8690eaef74a9719e