### PR TITLE
Fix PDF rendering line breaks

### DIFF
--- a/src/gaij/html_renderer.py
+++ b/src/gaij/html_renderer.py
@@ -19,7 +19,17 @@ def _simple_pdf_bytes(text: str) -> bytes:
 
     # Escape characters that have a special meaning in PDF text objects.
     esc = text.replace("\\", r"\\\\").replace("(", r"\\(").replace(")", r"\\)")
-    content = f"BT /F1 12 Tf 72 720 Td ({esc}) Tj ET"
+
+    # PDF ``Tj`` shows text only on the current line.  To preserve line
+    # breaks from the input we split the text and move the cursor down after
+    # each line using ``Td`` before rendering the next one.
+    lines = esc.split("\n")
+    parts: list[str] = []
+    for i, line in enumerate(lines):
+        if i:
+            parts.append("0 -14 Td")  # Move to the next line.
+        parts.append(f"({line}) Tj")
+    content = "BT /F1 12 Tf 72 720 Td " + " ".join(parts) + " ET"
 
     objects: list[str] = [
         "<< /Type /Catalog /Pages 2 0 R >>",

--- a/tests/test_html_renderer_linebreaks.py
+++ b/tests/test_html_renderer_linebreaks.py
@@ -5,4 +5,7 @@ def test_render_html_preserves_linebreaks_in_pdf():
     html = "<p>Line1<br>Line2</p>"
     pdf_bytes, name = render_html(html, [], fmt="pdf")
     assert name.endswith(".pdf")
-    assert b"Line1" in pdf_bytes and b"Line2" in pdf_bytes
+    # The PDF stream should render each line separately, moving the cursor
+    # down between them.  ``Td`` operations indicate line breaks.
+    assert b"(Line1) Tj 0 -14 Td" in pdf_bytes
+    assert b"0 -14 Td (Line2) Tj" in pdf_bytes


### PR DESCRIPTION
## Summary
- ensure PDF renderer moves cursor for each line of text
- test for PDF line break handling

## Testing
- `pytest`
- `pre-commit run --files src/gaij/html_renderer.py tests/test_html_renderer_linebreaks.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a954880c832e9242b510a4116bc5