### PR TITLE
Handle invalid GMAIL_TOKEN_FILE JSON and document token format

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,15 @@ echo $GMAIL_TOKEN_FILE_PATH
 
 If you prefer to inject the token content directly, set
 `GMAIL_TOKEN_FILE` to the JSON contents and the application will write
-the file to `GMAIL_TOKEN_FILE_PATH` on boot. A typical configuration
-inside Docker is:
+the file to `GMAIL_TOKEN_FILE_PATH` on boot. The value must be valid
+JSON matching the format of a standard Gmail OAuth token file, for
+example:
+
+```json
+{"token":"...","refresh_token":"...","token_uri":"https://oauth2.googleapis.com/token","client_id":"...","client_secret":"...","scopes":["https://www.googleapis.com/auth/gmail.readonly"]}
+```
+
+A typical configuration inside Docker is:
 
 ```
 export GMAIL_TOKEN_FILE_PATH=/app/token.json

--- a/src/gaij/gmail_client.py
+++ b/src/gaij/gmail_client.py
@@ -32,9 +32,9 @@ def get_gmail_service() -> Any:
         if token_json.startswith("{"):
             try:
                 creds = Credentials.from_authorized_user_info(json.loads(token_json), SCOPES)  # type: ignore[no-untyped-call]
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as err:
                 logger.error("Failed to parse JSON from GMAIL_TOKEN_FILE")
-                raise FileNotFoundError("Invalid GMAIL_TOKEN_FILE content")
+                raise FileNotFoundError("Invalid GMAIL_TOKEN_FILE content") from err
         else:
             logger.error(
                 "Gmail token not found. Checked path %s and GMAIL_TOKEN_FILE env.",

--- a/src/gaij/gmail_client.py
+++ b/src/gaij/gmail_client.py
@@ -30,7 +30,11 @@ def get_gmail_service() -> Any:
     else:
         token_json = os.environ.get("GMAIL_TOKEN_FILE", "").strip()
         if token_json.startswith("{"):
-            creds = Credentials.from_authorized_user_info(json.loads(token_json), SCOPES)  # type: ignore[no-untyped-call]
+            try:
+                creds = Credentials.from_authorized_user_info(json.loads(token_json), SCOPES)  # type: ignore[no-untyped-call]
+            except json.JSONDecodeError:
+                logger.error("Failed to parse JSON from GMAIL_TOKEN_FILE")
+                raise FileNotFoundError("Invalid GMAIL_TOKEN_FILE content")
         else:
             logger.error(
                 "Gmail token not found. Checked path %s and GMAIL_TOKEN_FILE env.",


### PR DESCRIPTION
## Summary
- Guard against JSON parsing errors when reading `GMAIL_TOKEN_FILE`
- Document required JSON structure for `GMAIL_TOKEN_FILE` in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9e7774788832e82d6338f942a8783