### PR TITLE
fix: detect Firestore location flag

### DIFF
--- a/infra/install.yml
+++ b/infra/install.yml
@@ -142,9 +142,10 @@
     - name: Ensure Firestore database exists (Native)
       shell: |
         gcloud firestore databases describe "(default)" --project {{ project_id }} >/dev/null 2>&1 || {
-          FLAG=$(gcloud firestore databases create --help | grep -q -- '--database-type' && echo '--database-type' || echo '--type')
+          TYPE_FLAG=$(gcloud firestore databases create --help | grep -q -- '--database-type' && echo '--database-type' || echo '--type')
+          LOC_FLAG=$(gcloud firestore databases create --help | grep -q -- '--location-id' && echo '--location-id' || echo '--location')
           gcloud firestore databases create --project {{ project_id }} \
-            --location-id={{ firestore_location_id }} "$FLAG={{ firestore_type }}"
+            "$LOC_FLAG={{ firestore_location_id }}" "$TYPE_FLAG={{ firestore_type }}"
         }
       changed_when: false
 


### PR DESCRIPTION
## Summary
- handle gcloud Firestore location flag change by detecting `--location` vs `--location-id`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9ef5a35e8832ea383a6a52d6a435c