### PR TITLE
Fix Cloud Build source directory for install

### DIFF
--- a/infra/install.yml
+++ b/infra/install.yml
@@ -205,7 +205,9 @@
       shell: |
         export IMAGE="{{ region }}-docker.pkg.dev/{{ project_id }}/{{ artifact_repo }}/{{ service_name }}:$(date +%Y%m%d%H%M%S)"
         echo "$IMAGE" > /tmp/cr_image.txt
-        gcloud builds submit "{{ source_dir }}" --tag "$IMAGE" --project "{{ project_id }}"
+        gcloud builds submit . --tag "$IMAGE" --project "{{ project_id }}"
+      args:
+        chdir: "{{ source_dir }}"
       changed_when: true
 
     - name: Read built image tag


### PR DESCRIPTION
## Summary
- ensure Cloud Build runs from the correct source directory during installation

## Testing
- `pip install -r requirements.txt`
- `pytest`
- ⚠️ `pre-commit run --files infra/install.yml` *(pre-commit not installed; installation failed: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f1aba0f0832ea9b7de14ae1625e0