### PR TITLE
Handle existing Firestore DB in installer

### DIFF
--- a/infra/install.yml
+++ b/infra/install.yml
@@ -145,7 +145,8 @@
           TYPE_FLAG=$(gcloud firestore databases create --help | grep -q -- '--database-type' && echo '--database-type' || echo '--type')
           LOC_FLAG=$(gcloud firestore databases create --help | grep -q -- '--location-id' && echo '--location-id' || echo '--location')
           gcloud firestore databases create --project {{ project_id }} \
-            "$LOC_FLAG={{ firestore_location_id }}" "$TYPE_FLAG={{ firestore_type }}"
+            "$LOC_FLAG={{ firestore_location_id }}" "$TYPE_FLAG={{ firestore_type }}" \
+            || gcloud firestore databases describe "(default)" --project {{ project_id }} >/dev/null 2>&1
         }
       changed_when: false
 


### PR DESCRIPTION
## Summary
- ensure Firestore database creation step doesn't fail when database already exists

## Testing
- `pre-commit run --files infra/install.yml` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9f3872900832eb083d4c2275e3904